### PR TITLE
Handle lenient CORS origin configuration

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,1 @@
+"""RefData Hub API package."""

--- a/api/app/config.py
+++ b/api/app/config.py
@@ -2,10 +2,32 @@
 
 from __future__ import annotations
 
-from typing import List
+from typing import Any, List
 
-from pydantic import Field
+import json
+
+from pydantic import Field, field_validator
+from pydantic.fields import FieldInfo
 from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic_settings.sources import DotEnvSettingsSource, EnvSettingsSource, PydanticBaseSettingsSource
+
+
+class LenientEnvSettingsSource(EnvSettingsSource):
+    """Environment source that defers complex parsing for select fields."""
+
+    def prepare_field_value(self, field_name: str, field: FieldInfo, value: Any, value_is_complex: bool) -> Any:  # type: ignore[override]
+        if field_name == "cors_origins" and isinstance(value, str):
+            return value
+        return super().prepare_field_value(field_name, field, value, value_is_complex)
+
+
+class LenientDotEnvSettingsSource(DotEnvSettingsSource):
+    """DotEnv source that mirrors the lenient behaviour for environment values."""
+
+    def prepare_field_value(self, field_name: str, field: FieldInfo, value: Any, value_is_complex: bool) -> Any:  # type: ignore[override]
+        if field_name == "cors_origins" and isinstance(value, str):
+            return value
+        return super().prepare_field_value(field_name, field, value, value_is_complex)
 
 
 class Settings(BaseSettings):
@@ -44,8 +66,71 @@ class Settings(BaseSettings):
     )
 
     model_config = SettingsConfigDict(
-        env_file=".env", env_prefix="REFDATA_", extra="ignore"
+        env_file=".env",
+        env_prefix="REFDATA_",
+        extra="ignore",
     )
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> tuple[PydanticBaseSettingsSource, ...]:
+        return (
+            init_settings,
+            LenientEnvSettingsSource(settings_cls),
+            LenientDotEnvSettingsSource(settings_cls),
+            file_secret_settings,
+        )
+
+    @field_validator("cors_origins", mode="before")
+    @classmethod
+    def parse_cors_origins(cls, value: Any) -> List[str]:
+        """Normalise CORS origins from environment variables.
+
+        The validator accepts either JSON encoded lists/strings or comma separated values.
+        Empty strings fall back to the configured defaults to avoid parsing errors.
+        """
+
+        if value in (None, ""):
+            default_factory = cls.model_fields["cors_origins"].default_factory
+            default_value = cls.model_fields["cors_origins"].default
+            if default_factory is not None:
+                return list(default_factory())
+            if isinstance(default_value, list):
+                return list(default_value)
+            raise ValueError("cors_origins default is not configured as a list")
+
+        if isinstance(value, str):
+            stripped = value.strip()
+            if not stripped:
+                return cls.parse_cors_origins("")
+            try:
+                parsed = json.loads(stripped)
+            except json.JSONDecodeError:
+                origins = [origin.strip() for origin in stripped.split(",") if origin.strip()]
+                return origins or cls.parse_cors_origins("")
+        else:
+            parsed = value
+
+        if isinstance(parsed, str):
+            return [parsed.strip()] if parsed.strip() else cls.parse_cors_origins("")
+
+        if isinstance(parsed, list):
+            normalised: List[str] = []
+            for item in parsed:
+                if not isinstance(item, str):
+                    raise ValueError("cors_origins list entries must be strings")
+                cleaned = item.strip()
+                if cleaned:
+                    normalised.append(cleaned)
+            return normalised or cls.parse_cors_origins("")
+
+        raise ValueError("cors_origins must be provided as a string or list of strings")
 
 
 def load_settings() -> Settings:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,76 @@
+"""Unit tests for configuration handling."""
+
+from __future__ import annotations
+
+from typing import List
+
+import os
+
+import pytest
+
+from api.app.config import Settings
+
+
+def _reset_env(var_name: str) -> None:
+    os.environ.pop(var_name, None)
+
+
+@pytest.fixture(autouse=True)
+def clear_env() -> List[str]:
+    """Ensure environment mutations from tests do not leak."""
+
+    existing = os.environ.get("REFDATA_CORS_ORIGINS")
+    try:
+        yield
+    finally:
+        if existing is None:
+            _reset_env("REFDATA_CORS_ORIGINS")
+        else:
+            os.environ["REFDATA_CORS_ORIGINS"] = existing
+
+
+def test_cors_origins_default_is_preserved() -> None:
+    settings = Settings()
+    assert settings.cors_origins == [
+        "http://localhost:5173",
+        "http://127.0.0.1:5173",
+    ]
+
+
+def test_cors_origins_accepts_comma_separated_values() -> None:
+    os.environ["REFDATA_CORS_ORIGINS"] = "https://example.com, https://foo.bar"
+    settings = Settings()
+    assert settings.cors_origins == [
+        "https://example.com",
+        "https://foo.bar",
+    ]
+
+
+def test_cors_origins_accepts_json_list() -> None:
+    os.environ["REFDATA_CORS_ORIGINS"] = "[\"https://one\", \"https://two\"]"
+    settings = Settings()
+    assert settings.cors_origins == [
+        "https://one",
+        "https://two",
+    ]
+
+
+def test_cors_origins_handles_single_json_string() -> None:
+    os.environ["REFDATA_CORS_ORIGINS"] = '"https://solo"'
+    settings = Settings()
+    assert settings.cors_origins == ["https://solo"]
+
+
+def test_cors_origins_falls_back_to_default_on_blank_string() -> None:
+    os.environ["REFDATA_CORS_ORIGINS"] = ""
+    settings = Settings()
+    assert settings.cors_origins == [
+        "http://localhost:5173",
+        "http://127.0.0.1:5173",
+    ]
+
+
+def test_cors_origins_rejects_non_string_entries() -> None:
+    os.environ["REFDATA_CORS_ORIGINS"] = "[\"https://one\", 42]"
+    with pytest.raises(ValueError):
+        Settings()


### PR DESCRIPTION
## Summary
- add lenient settings sources so `cors_origins` environment variables no longer raise JSON decoding errors when left blank or comma-separated
- normalise CORS origin inputs through a dedicated validator and broaden parsing support
- cover configuration parsing with targeted unit tests and register the `api` package root

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d525fcf3bc83329f37d5bbaf053ee5