### PR TITLE
Implement source integration workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,32 @@ This command starts:
 
 The first boot performs all schema creation and seeding automatically. All runtime changes (matching thresholds, preferred matcher backend, API keys, additional canonical values, etc.) should be made through the Reviewer UI. No extra scripts are required after `docker compose up`.
 
+### Reviewer UI at a glance
+
+The interface is organised into task-focused pages that surface the entire curation workflow:
+
+- **Dashboard** – configure matcher parameters, experiment with semantic suggestions, and curate canonical values with inline editing.
+- **Source Connections** – register and maintain connectivity metadata for upstream systems.
+- **Field Mappings** – align source tables/fields to reference dimensions and ingest sample values for reconciliation analytics.
+- **Match Insights** – visualise match rates per mapping, inspect top outliers, and track overall harmonisation health.
+- **Suggestions** – approve semantic suggestions or manually link raw values to canonical standards.
+- **Mapping History** – audit every approved mapping, edit or retire entries, and export a normalised view per connection.
+
+### API highlights
+
+The FastAPI service now exposes a rich set of endpoints under `/api`:
+
+- `/reference/canonical` – full CRUD for canonical reference values.
+- `/source/connections` – manage source system connection metadata.
+- `/source/connections/{id}/mappings` – create/update/delete field mappings to reference dimensions.
+- `/source/connections/{id}/samples` – ingest aggregated raw samples collected from source systems or manual uploads.
+- `/source/connections/{id}/match-stats` – compute match rates, top unmatched values, and semantic suggestions.
+- `/source/connections/{id}/unmatched` – retrieve unmatched raw values with inline suggestions for remediation.
+- `/source/connections/{id}/value-mappings` – approve, update, or delete specific raw-to-canonical mappings.
+- `/source/value-mappings` – consolidated view of all mappings across connections.
+
+Endpoints accept and return structured JSON payloads that align with the React TypeScript models in `reviewer-ui/src/types.ts`.
+
 ## Project Structure
 
 ```
@@ -31,7 +57,7 @@ The first boot performs all schema creation and seeding automatically. All runti
 └── README.md
 ```
 
-Each directory currently contains a placeholder `.gitkeep` file to keep the structure under version control. Implementation details will evolve as components are developed. The Reviewer UI now ships with a polished Material UI experience that can switch between accessible dark, warm, cool, and lively themes directly from the header.
+The repository now contains a fully functional end-to-end workflow with integration tests in `tests/`, a semantic matcher in `matcher/`, a FastAPI backend in `api/`, and a multi-page React dashboard in `reviewer-ui/` with accessible theme switching baked into the header.
 
 ## Feature Breakdown
 

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -9,6 +9,7 @@ from .config import Settings, load_settings
 from .database import create_db_engine, init_db
 from .routes import config as config_routes
 from .routes import reference as reference_routes
+from .routes import source as source_routes
 
 
 def create_app(settings: Settings | None = None) -> FastAPI:
@@ -33,6 +34,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     api_router = APIRouter(prefix="/api")
     api_router.include_router(reference_routes.router)
     api_router.include_router(config_routes.router)
+    api_router.include_router(source_routes.router)
     app.include_router(api_router)
 
     @app.get("/health", tags=["health"])

--- a/api/app/models.py
+++ b/api/app/models.py
@@ -58,3 +58,118 @@ class SystemConfig(SQLModel, table=True):
         """Update the timestamp when settings change."""
 
         self.updated_at = datetime.now(timezone.utc)
+
+
+class SourceConnection(SQLModel, table=True):
+    """Connection metadata for external source systems."""
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    name: str = Field(
+        index=True,
+        description="Human readable name for the connection.",
+        sa_column_kwargs={"unique": True},
+    )
+    db_type: str = Field(
+        description="Database technology (postgres, mysql, snowflake, etc.)."
+    )
+    host: str = Field(description="Hostname or address of the database server.")
+    port: int = Field(default=5432, description="Database port number.")
+    database: str = Field(description="Database or schema name.")
+    username: str = Field(description="Service account username.")
+    password: Optional[str] = Field(
+        default=None,
+        description="Optional credential stored securely in the database.",
+    )
+    options: Optional[str] = Field(
+        default=None,
+        description="JSON encoded optional parameters (SSL mode, warehouse, etc.).",
+    )
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc), nullable=False
+    )
+    updated_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc), nullable=False
+    )
+
+    def touch(self) -> None:
+        """Update the modification timestamp."""
+
+        self.updated_at = datetime.now(timezone.utc)
+
+
+class SourceFieldMapping(SQLModel, table=True):
+    """Mapping metadata between source fields and canonical dimensions."""
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    source_connection_id: int = Field(
+        foreign_key="sourceconnection.id", index=True, nullable=False
+    )
+    source_table: str = Field(description="Table or collection containing the field.")
+    source_field: str = Field(description="Column name within the source table.")
+    ref_dimension: str = Field(
+        description="Canonical reference dimension the field harmonizes to."
+    )
+    description: Optional[str] = Field(default=None)
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc), nullable=False
+    )
+    updated_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc), nullable=False
+    )
+
+    def touch(self) -> None:
+        """Update the modification timestamp."""
+
+        self.updated_at = datetime.now(timezone.utc)
+
+
+class SourceSample(SQLModel, table=True):
+    """Aggregated samples for raw values sourced from external systems."""
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    source_connection_id: int = Field(
+        foreign_key="sourceconnection.id", index=True, nullable=False
+    )
+    source_table: str = Field(index=True)
+    source_field: str = Field(index=True)
+    dimension: Optional[str] = Field(
+        default=None,
+        description="Optional dimension hint captured with the sample.",
+    )
+    raw_value: str = Field(description="Observed raw value.")
+    occurrence_count: int = Field(default=1, ge=0)
+    last_seen_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc), nullable=False
+    )
+
+
+class ValueMapping(SQLModel, table=True):
+    """Approved mappings from raw source values to canonical entries."""
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    source_connection_id: int = Field(
+        foreign_key="sourceconnection.id", index=True, nullable=False
+    )
+    source_table: str = Field(index=True)
+    source_field: str = Field(index=True)
+    raw_value: str = Field(index=True)
+    canonical_id: int = Field(
+        foreign_key="canonicalvalue.id", description="Mapped canonical value identifier."
+    )
+    status: str = Field(default="approved", index=True)
+    confidence: Optional[float] = Field(
+        default=None, description="Confidence score captured at approval time."
+    )
+    suggested_label: Optional[str] = Field(default=None)
+    notes: Optional[str] = Field(default=None)
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc), nullable=False
+    )
+    updated_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc), nullable=False
+    )
+
+    def touch(self) -> None:
+        """Update modification timestamp."""
+
+        self.updated_at = datetime.now(timezone.utc)

--- a/api/app/routes/__init__.py
+++ b/api/app/routes/__init__.py
@@ -1,1 +1,5 @@
 """API routers."""
+
+from . import config, reference, source
+
+__all__ = ["config", "reference", "source"]

--- a/api/app/routes/source.py
+++ b/api/app/routes/source.py
@@ -1,0 +1,613 @@
+"""Routes managing source system integrations and harmonization workflows."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Iterable, List, Sequence
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
+from sqlalchemy.exc import IntegrityError
+from sqlmodel import Session, and_, delete, select
+
+from ..database import get_session
+from ..matcher import SemanticMatcher
+from ..models import (
+    CanonicalValue,
+    SourceConnection,
+    SourceFieldMapping,
+    SourceSample,
+    SystemConfig,
+    ValueMapping,
+)
+from ..schemas import (
+    FieldMatchStats,
+    SourceConnectionCreate,
+    SourceConnectionRead,
+    SourceConnectionUpdate,
+    SourceFieldMappingCreate,
+    SourceFieldMappingRead,
+    SourceFieldMappingUpdate,
+    SourceSampleIngestRequest,
+    SourceSampleRead,
+    UnmatchedValuePreview,
+    UnmatchedValueRecord,
+    ValueMappingCreate,
+    ValueMappingExpanded,
+    ValueMappingRead,
+    ValueMappingUpdate,
+)
+
+
+router = APIRouter(prefix="/source", tags=["source"])
+
+
+def _get_config(session: Session) -> SystemConfig:
+    config = session.exec(select(SystemConfig)).first()
+    if not config:
+        raise HTTPException(status_code=500, detail="System configuration missing")
+    return config
+
+
+def _require_connection(session: Session, connection_id: int) -> SourceConnection:
+    connection = session.get(SourceConnection, connection_id)
+    if not connection:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Connection not found")
+    return connection
+
+
+def _load_canonical_values(
+    session: Session, dimension: str
+) -> Sequence[CanonicalValue]:
+    statement = select(CanonicalValue).where(CanonicalValue.dimension == dimension)
+    return session.exec(statement).all()
+
+
+def _canonical_lookup(session: Session, identifiers: set[int]) -> dict[int, CanonicalValue]:
+    if not identifiers:
+        return {}
+    statement = select(CanonicalValue).where(CanonicalValue.id.in_(identifiers))
+    return {canonical.id: canonical for canonical in session.exec(statement).all()}
+
+
+@router.get("/connections", response_model=List[SourceConnectionRead])
+def list_connections(session: Session = Depends(get_session)) -> List[SourceConnection]:
+    statement = select(SourceConnection).order_by(SourceConnection.name)
+    return session.exec(statement).all()
+
+
+@router.post(
+    "/connections",
+    response_model=SourceConnectionRead,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_connection(
+    payload: SourceConnectionCreate, session: Session = Depends(get_session)
+) -> SourceConnection:
+    connection = SourceConnection(**payload.model_dump())
+    try:
+        session.add(connection)
+        session.commit()
+    except IntegrityError as exc:  # pragma: no cover - exercised via tests
+        session.rollback()
+        raise HTTPException(status_code=400, detail="Connection name must be unique") from exc
+
+    session.refresh(connection)
+    return connection
+
+
+@router.put("/connections/{connection_id}", response_model=SourceConnectionRead)
+def update_connection(
+    connection_id: int,
+    payload: SourceConnectionUpdate,
+    session: Session = Depends(get_session),
+) -> SourceConnection:
+    connection = _require_connection(session, connection_id)
+    data = payload.model_dump(exclude_unset=True)
+    if not data:
+        return connection
+
+    password = data.pop("password", None)
+    for key, value in data.items():
+        setattr(connection, key, value)
+
+    if password is not None:
+        connection.password = password
+
+    connection.touch()
+    try:
+        session.add(connection)
+        session.commit()
+    except IntegrityError as exc:
+        session.rollback()
+        raise HTTPException(status_code=400, detail="Connection name must be unique") from exc
+
+    session.refresh(connection)
+    return connection
+
+
+@router.delete("/connections/{connection_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_connection(
+    connection_id: int, session: Session = Depends(get_session)
+) -> Response:
+    connection = _require_connection(session, connection_id)
+
+    # Cascade deletes manually because SQLite lacks ON DELETE CASCADE by default.
+    session.exec(
+        delete(SourceFieldMapping).where(
+            SourceFieldMapping.source_connection_id == connection_id
+        )
+    )
+    session.exec(
+        delete(SourceSample).where(SourceSample.source_connection_id == connection_id)
+    )
+    session.exec(
+        delete(ValueMapping).where(ValueMapping.source_connection_id == connection_id)
+    )
+
+    session.delete(connection)
+    session.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.get(
+    "/connections/{connection_id}/mappings",
+    response_model=List[SourceFieldMappingRead],
+)
+def list_field_mappings(
+    connection_id: int,
+    session: Session = Depends(get_session),
+) -> List[SourceFieldMapping]:
+    _require_connection(session, connection_id)
+    statement = (
+        select(SourceFieldMapping)
+        .where(SourceFieldMapping.source_connection_id == connection_id)
+        .order_by(SourceFieldMapping.source_table, SourceFieldMapping.source_field)
+    )
+    return session.exec(statement).all()
+
+
+@router.post(
+    "/connections/{connection_id}/mappings",
+    response_model=SourceFieldMappingRead,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_field_mapping(
+    connection_id: int,
+    payload: SourceFieldMappingCreate,
+    session: Session = Depends(get_session),
+) -> SourceFieldMapping:
+    _require_connection(session, connection_id)
+    mapping = SourceFieldMapping(
+        source_connection_id=connection_id, **payload.model_dump()
+    )
+    session.add(mapping)
+    session.commit()
+    session.refresh(mapping)
+    return mapping
+
+
+@router.put(
+    "/connections/{connection_id}/mappings/{mapping_id}",
+    response_model=SourceFieldMappingRead,
+)
+def update_field_mapping(
+    connection_id: int,
+    mapping_id: int,
+    payload: SourceFieldMappingUpdate,
+    session: Session = Depends(get_session),
+) -> SourceFieldMapping:
+    _require_connection(session, connection_id)
+    mapping = session.get(SourceFieldMapping, mapping_id)
+    if not mapping or mapping.source_connection_id != connection_id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Mapping not found")
+
+    for key, value in payload.model_dump(exclude_unset=True).items():
+        setattr(mapping, key, value)
+
+    mapping.touch()
+    session.add(mapping)
+    session.commit()
+    session.refresh(mapping)
+    return mapping
+
+
+@router.delete(
+    "/connections/{connection_id}/mappings/{mapping_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+def delete_field_mapping(
+    connection_id: int, mapping_id: int, session: Session = Depends(get_session)
+) -> Response:
+    _require_connection(session, connection_id)
+    mapping = session.get(SourceFieldMapping, mapping_id)
+    if not mapping or mapping.source_connection_id != connection_id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Mapping not found")
+
+    session.delete(mapping)
+    session.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.get(
+    "/connections/{connection_id}/samples",
+    response_model=List[SourceSampleRead],
+)
+def list_samples(
+    connection_id: int,
+    source_table: str | None = Query(default=None),
+    source_field: str | None = Query(default=None),
+    session: Session = Depends(get_session),
+) -> List[SourceSample]:
+    _require_connection(session, connection_id)
+    statement = select(SourceSample).where(
+        SourceSample.source_connection_id == connection_id
+    )
+    if source_table:
+        statement = statement.where(SourceSample.source_table == source_table)
+    if source_field:
+        statement = statement.where(SourceSample.source_field == source_field)
+
+    statement = statement.order_by(
+        SourceSample.source_table, SourceSample.source_field, SourceSample.raw_value
+    )
+    return session.exec(statement).all()
+
+
+@router.post(
+    "/connections/{connection_id}/samples",
+    response_model=List[SourceSampleRead],
+    status_code=status.HTTP_201_CREATED,
+)
+def ingest_samples(
+    connection_id: int,
+    payload: SourceSampleIngestRequest,
+    session: Session = Depends(get_session),
+) -> List[SourceSample]:
+    _require_connection(session, connection_id)
+    now = datetime.now(timezone.utc)
+    updated: list[SourceSample] = []
+
+    for value in payload.values:
+        statement = select(SourceSample).where(
+            and_(
+                SourceSample.source_connection_id == connection_id,
+                SourceSample.source_table == payload.source_table,
+                SourceSample.source_field == payload.source_field,
+                SourceSample.raw_value == value.raw_value,
+            )
+        )
+        sample = session.exec(statement).first()
+        if sample:
+            sample.occurrence_count += value.occurrence_count
+            sample.dimension = value.dimension or sample.dimension
+            sample.last_seen_at = now
+        else:
+            sample = SourceSample(
+                source_connection_id=connection_id,
+                source_table=payload.source_table,
+                source_field=payload.source_field,
+                dimension=value.dimension,
+                raw_value=value.raw_value,
+                occurrence_count=value.occurrence_count,
+                last_seen_at=now,
+            )
+            session.add(sample)
+        updated.append(sample)
+
+    session.commit()
+    for sample in updated:
+        session.refresh(sample)
+    return updated
+
+
+def _suggestions_for_samples(
+    samples: Iterable[SourceSample],
+    matcher: SemanticMatcher,
+    threshold: float,
+    mapped_values: set[str],
+) -> tuple[int, List[UnmatchedValuePreview]]:
+    matched_count = 0
+    unmatched: list[UnmatchedValuePreview] = []
+    for sample in samples:
+        if sample.raw_value in mapped_values:
+            matched_count += sample.occurrence_count
+            continue
+
+        ranked = matcher.rank(sample.raw_value)
+        if ranked and ranked[0].score >= threshold:
+            matched_count += sample.occurrence_count
+            continue
+
+        candidate_threshold = max(threshold * 0.75, 0.2)
+        suggestions = [
+            match for match in ranked if match.score >= candidate_threshold
+        ][:3]
+        unmatched.append(
+            UnmatchedValuePreview(
+                raw_value=sample.raw_value,
+                occurrence_count=sample.occurrence_count,
+                suggestions=suggestions,
+            )
+        )
+
+    return matched_count, unmatched
+
+
+@router.get(
+    "/connections/{connection_id}/match-stats",
+    response_model=List[FieldMatchStats],
+)
+def compute_match_statistics(
+    connection_id: int, session: Session = Depends(get_session)
+) -> List[FieldMatchStats]:
+    connection = _require_connection(session, connection_id)
+    config = _get_config(session)
+
+    mappings = session.exec(
+        select(SourceFieldMapping)
+        .where(SourceFieldMapping.source_connection_id == connection.id)
+        .order_by(SourceFieldMapping.source_table, SourceFieldMapping.source_field)
+    ).all()
+
+    results: list[FieldMatchStats] = []
+
+    for mapping in mappings:
+        canonical_values = _load_canonical_values(session, mapping.ref_dimension)
+        matcher = SemanticMatcher(config=config, canonical_values=canonical_values)
+
+        samples = session.exec(
+            select(SourceSample).where(
+                and_(
+                    SourceSample.source_connection_id == connection.id,
+                    SourceSample.source_table == mapping.source_table,
+                    SourceSample.source_field == mapping.source_field,
+                )
+            )
+        ).all()
+
+        total = sum(sample.occurrence_count for sample in samples)
+        mapped_values = {
+            vm.raw_value
+            for vm in session.exec(
+                select(ValueMapping).where(
+                    and_(
+                        ValueMapping.source_connection_id == connection.id,
+                        ValueMapping.source_table == mapping.source_table,
+                        ValueMapping.source_field == mapping.source_field,
+                    )
+                )
+            ).all()
+        }
+
+        matched_count, unmatched = _suggestions_for_samples(
+            samples, matcher, config.match_threshold, mapped_values
+        )
+        unmatched.sort(key=lambda item: item.occurrence_count, reverse=True)
+
+        results.append(
+            FieldMatchStats(
+                mapping_id=mapping.id or 0,
+                source_table=mapping.source_table,
+                source_field=mapping.source_field,
+                ref_dimension=mapping.ref_dimension,
+                total_values=total,
+                matched_values=matched_count,
+                unmatched_values=max(total - matched_count, 0),
+                match_rate=float(matched_count / total) if total else 0.0,
+                top_unmatched=unmatched[:10],
+            )
+        )
+
+    return results
+
+
+@router.get(
+    "/connections/{connection_id}/unmatched",
+    response_model=List[UnmatchedValueRecord],
+)
+def list_unmatched_values(
+    connection_id: int,
+    session: Session = Depends(get_session),
+) -> List[UnmatchedValueRecord]:
+    connection = _require_connection(session, connection_id)
+    config = _get_config(session)
+
+    mappings = session.exec(
+        select(SourceFieldMapping)
+        .where(SourceFieldMapping.source_connection_id == connection.id)
+    ).all()
+
+    records: list[UnmatchedValueRecord] = []
+    value_mapping_index: dict[tuple[str, str], set[str]] = {}
+    for vm in session.exec(
+        select(ValueMapping).where(ValueMapping.source_connection_id == connection.id)
+    ).all():
+        key = (vm.source_table, vm.source_field)
+        value_mapping_index.setdefault(key, set()).add(vm.raw_value)
+
+    for mapping in mappings:
+        canonical_values = _load_canonical_values(session, mapping.ref_dimension)
+        matcher = SemanticMatcher(config=config, canonical_values=canonical_values)
+        samples = session.exec(
+            select(SourceSample).where(
+                and_(
+                    SourceSample.source_connection_id == connection.id,
+                    SourceSample.source_table == mapping.source_table,
+                    SourceSample.source_field == mapping.source_field,
+                )
+            )
+        ).all()
+
+        _, unmatched = _suggestions_for_samples(
+            samples,
+            matcher,
+            config.match_threshold,
+            value_mapping_index.get((mapping.source_table, mapping.source_field), set()),
+        )
+
+        for item in unmatched:
+            records.append(
+                UnmatchedValueRecord(
+                    mapping_id=mapping.id or 0,
+                    source_table=mapping.source_table,
+                    source_field=mapping.source_field,
+                    ref_dimension=mapping.ref_dimension,
+                    raw_value=item.raw_value,
+                    occurrence_count=item.occurrence_count,
+                    suggestions=item.suggestions,
+                )
+            )
+
+    records.sort(key=lambda item: item.occurrence_count, reverse=True)
+    return records
+
+
+@router.post(
+    "/connections/{connection_id}/value-mappings",
+    response_model=ValueMappingRead,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_value_mapping(
+    connection_id: int,
+    payload: ValueMappingCreate,
+    session: Session = Depends(get_session),
+) -> ValueMapping:
+    _require_connection(session, connection_id)
+    canonical = session.get(CanonicalValue, payload.canonical_id)
+    if not canonical:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Canonical value not found")
+
+    mapping = ValueMapping(
+        source_connection_id=connection_id,
+        **payload.model_dump(),
+    )
+    mapping.touch()
+    session.add(mapping)
+    session.commit()
+    session.refresh(mapping)
+    return mapping
+
+
+@router.get(
+    "/connections/{connection_id}/value-mappings",
+    response_model=List[ValueMappingExpanded],
+)
+def list_value_mappings(
+    connection_id: int,
+    session: Session = Depends(get_session),
+) -> List[ValueMappingExpanded]:
+    _require_connection(session, connection_id)
+    statement = select(ValueMapping).where(
+        ValueMapping.source_connection_id == connection_id
+    )
+    records = session.exec(statement).all()
+
+    expanded: list[ValueMappingExpanded] = []
+    canonical_by_id = _canonical_lookup(
+        session, {record.canonical_id for record in records}
+    )
+
+    for record in records:
+        canonical = canonical_by_id.get(record.canonical_id)
+        expanded.append(
+            ValueMappingExpanded(
+                id=record.id or 0,
+                source_connection_id=record.source_connection_id,
+                source_table=record.source_table,
+                source_field=record.source_field,
+                raw_value=record.raw_value,
+                canonical_id=record.canonical_id,
+                status=record.status,
+                confidence=record.confidence,
+                suggested_label=record.suggested_label,
+                notes=record.notes,
+                created_at=record.created_at,
+                updated_at=record.updated_at,
+                canonical_label=canonical.canonical_label if canonical else "Unknown",
+                ref_dimension=canonical.dimension if canonical else "",
+            )
+        )
+
+    expanded.sort(key=lambda item: (item.source_table, item.source_field, item.raw_value))
+    return expanded
+
+
+@router.put(
+    "/connections/{connection_id}/value-mappings/{mapping_id}",
+    response_model=ValueMappingRead,
+)
+def update_value_mapping(
+    connection_id: int,
+    mapping_id: int,
+    payload: ValueMappingUpdate,
+    session: Session = Depends(get_session),
+) -> ValueMapping:
+    _require_connection(session, connection_id)
+    mapping = session.get(ValueMapping, mapping_id)
+    if not mapping or mapping.source_connection_id != connection_id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Value mapping not found")
+
+    data = payload.model_dump(exclude_unset=True)
+    canonical_id = data.get("canonical_id")
+    if canonical_id is not None and not session.get(CanonicalValue, canonical_id):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Canonical value not found")
+
+    for key, value in data.items():
+        setattr(mapping, key, value)
+
+    mapping.touch()
+    session.add(mapping)
+    session.commit()
+    session.refresh(mapping)
+    return mapping
+
+
+@router.delete(
+    "/connections/{connection_id}/value-mappings/{mapping_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+def delete_value_mapping(
+    connection_id: int, mapping_id: int, session: Session = Depends(get_session)
+) -> Response:
+    _require_connection(session, connection_id)
+    mapping = session.get(ValueMapping, mapping_id)
+    if not mapping or mapping.source_connection_id != connection_id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Value mapping not found")
+
+    session.delete(mapping)
+    session.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.get("/value-mappings", response_model=List[ValueMappingExpanded])
+def list_all_value_mappings(session: Session = Depends(get_session)) -> List[ValueMappingExpanded]:
+    statement = select(ValueMapping)
+    records = session.exec(statement).all()
+    canonical_by_id = _canonical_lookup(
+        session, {record.canonical_id for record in records}
+    )
+
+    expanded: list[ValueMappingExpanded] = []
+    for record in records:
+        canonical = canonical_by_id.get(record.canonical_id)
+        expanded.append(
+            ValueMappingExpanded(
+                id=record.id or 0,
+                source_connection_id=record.source_connection_id,
+                source_table=record.source_table,
+                source_field=record.source_field,
+                raw_value=record.raw_value,
+                canonical_id=record.canonical_id,
+                status=record.status,
+                confidence=record.confidence,
+                suggested_label=record.suggested_label,
+                notes=record.notes,
+                created_at=record.created_at,
+                updated_at=record.updated_at,
+                canonical_label=canonical.canonical_label if canonical else "Unknown",
+                ref_dimension=canonical.dimension if canonical else "",
+            )
+        )
+
+    expanded.sort(key=lambda item: (item.source_connection_id, item.source_table, item.source_field, item.raw_value))
+    return expanded

--- a/api/app/schemas.py
+++ b/api/app/schemas.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import List, Optional
 
 from pydantic import BaseModel, Field, ConfigDict
@@ -21,6 +22,12 @@ class CanonicalValueRead(CanonicalValueBase):
     id: int
 
     model_config = ConfigDict(from_attributes=True)
+
+
+class CanonicalValueUpdate(BaseModel):
+    dimension: Optional[str] = None
+    canonical_label: Optional[str] = None
+    description: Optional[str] = None
 
 
 class RawValueRead(BaseModel):
@@ -72,3 +79,153 @@ class SystemConfigUpdate(BaseModel):
     llm_api_base: Optional[str] = None
     top_k: Optional[int] = Field(default=None, ge=1, le=20)
     llm_api_key: Optional[str] = Field(default=None, min_length=4)
+
+
+class SourceConnectionBase(BaseModel):
+    name: str
+    db_type: str
+    host: str
+    port: int = 5432
+    database: str
+    username: str
+    options: Optional[str] = None
+
+
+class SourceConnectionCreate(SourceConnectionBase):
+    password: Optional[str] = Field(default=None, min_length=1)
+
+
+class SourceConnectionRead(SourceConnectionBase):
+    id: int
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class SourceConnectionUpdate(BaseModel):
+    name: Optional[str] = None
+    db_type: Optional[str] = None
+    host: Optional[str] = None
+    port: Optional[int] = Field(default=None, ge=1, le=65535)
+    database: Optional[str] = None
+    username: Optional[str] = None
+    password: Optional[str] = Field(default=None, min_length=1)
+    options: Optional[str] = None
+
+
+class SourceFieldMappingBase(BaseModel):
+    source_table: str
+    source_field: str
+    ref_dimension: str
+    description: Optional[str] = None
+
+
+class SourceFieldMappingCreate(SourceFieldMappingBase):
+    pass
+
+
+class SourceFieldMappingRead(SourceFieldMappingBase):
+    id: int
+    source_connection_id: int
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class SourceFieldMappingUpdate(BaseModel):
+    source_table: Optional[str] = None
+    source_field: Optional[str] = None
+    ref_dimension: Optional[str] = None
+    description: Optional[str] = None
+
+
+class SourceSampleValue(BaseModel):
+    raw_value: str
+    occurrence_count: int = Field(default=1, ge=0)
+    dimension: Optional[str] = None
+
+
+class SourceSampleIngestRequest(BaseModel):
+    source_table: str
+    source_field: str
+    values: List[SourceSampleValue]
+
+
+class SourceSampleRead(BaseModel):
+    id: int
+    source_connection_id: int
+    source_table: str
+    source_field: str
+    dimension: Optional[str]
+    raw_value: str
+    occurrence_count: int
+    last_seen_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class UnmatchedValuePreview(BaseModel):
+    raw_value: str
+    occurrence_count: int
+    suggestions: List[MatchCandidate]
+
+
+class UnmatchedValueRecord(UnmatchedValuePreview):
+    mapping_id: int
+    source_table: str
+    source_field: str
+    ref_dimension: str
+
+
+class FieldMatchStats(BaseModel):
+    mapping_id: int
+    source_table: str
+    source_field: str
+    ref_dimension: str
+    total_values: int
+    matched_values: int
+    unmatched_values: int
+    match_rate: float
+    top_unmatched: List[UnmatchedValuePreview]
+
+
+class ValueMappingBase(BaseModel):
+    source_table: str
+    source_field: str
+    raw_value: str
+    canonical_id: int
+    status: Optional[str] = Field(default="approved")
+    confidence: Optional[float] = Field(default=None, ge=0.0, le=1.0)
+    suggested_label: Optional[str] = None
+    notes: Optional[str] = None
+
+
+class ValueMappingCreate(ValueMappingBase):
+    pass
+
+
+class ValueMappingRead(ValueMappingBase):
+    id: int
+    source_connection_id: int
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ValueMappingUpdate(BaseModel):
+    source_table: Optional[str] = None
+    source_field: Optional[str] = None
+    raw_value: Optional[str] = None
+    canonical_id: Optional[int] = None
+    status: Optional[str] = None
+    confidence: Optional[float] = Field(default=None, ge=0.0, le=1.0)
+    suggested_label: Optional[str] = None
+    notes: Optional[str] = None
+
+
+class ValueMappingExpanded(ValueMappingRead):
+    canonical_label: str
+    ref_dimension: str

--- a/reviewer-ui/package-lock.json
+++ b/reviewer-ui/package-lock.json
@@ -13,7 +13,8 @@
         "@mui/icons-material": "^5.15.17",
         "@mui/material": "^5.15.17",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "react-router-dom": "^6.23.0"
       },
       "devDependencies": {
         "@types/react": "^18.2.37",
@@ -1128,6 +1129,15 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
+      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -2134,6 +2144,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
+      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
+      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0",
+        "react-router": "6.30.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-transition-group": {

--- a/reviewer-ui/package.json
+++ b/reviewer-ui/package.json
@@ -14,7 +14,8 @@
     "@mui/icons-material": "^5.15.17",
     "@mui/material": "^5.15.17",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.23.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.37",

--- a/reviewer-ui/src/api.ts
+++ b/reviewer-ui/src/api.ts
@@ -1,8 +1,22 @@
 import type {
   CanonicalValue,
+  CanonicalValueUpdatePayload,
+  FieldMatchStats,
   MatchResponse,
+  SourceConnection,
+  SourceConnectionCreatePayload,
+  SourceConnectionUpdatePayload,
+  SourceFieldMapping,
+  SourceFieldMappingPayload,
+  SourceSample,
+  SourceSampleValuePayload,
   SystemConfig,
   SystemConfigUpdate,
+  UnmatchedValueRecord,
+  ValueMapping,
+  ValueMappingExpanded,
+  ValueMappingPayload,
+  ValueMappingUpdatePayload,
 } from './types';
 
 const fallbackBaseUrl = () => {
@@ -35,13 +49,35 @@ export async function fetchCanonicalValues(): Promise<CanonicalValue[]> {
   return handleResponse<CanonicalValue[]>(response);
 }
 
-export async function createCanonicalValue(payload: Partial<CanonicalValue>): Promise<CanonicalValue> {
+export async function createCanonicalValue(payload: CanonicalValueUpdatePayload): Promise<CanonicalValue> {
   const response = await fetch(`${API_BASE_URL}/api/reference/canonical`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload),
   });
   return handleResponse<CanonicalValue>(response);
+}
+
+export async function updateCanonicalValue(
+  id: number,
+  payload: CanonicalValueUpdatePayload,
+): Promise<CanonicalValue> {
+  const response = await fetch(`${API_BASE_URL}/api/reference/canonical/${id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  return handleResponse<CanonicalValue>(response);
+}
+
+export async function deleteCanonicalValue(id: number): Promise<void> {
+  const response = await fetch(`${API_BASE_URL}/api/reference/canonical/${id}`, {
+    method: 'DELETE',
+  });
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(message || 'Unable to delete canonical value');
+  }
 }
 
 export async function proposeMatch(raw_text: string, dimension?: string): Promise<MatchResponse> {
@@ -65,4 +101,192 @@ export async function updateConfig(payload: SystemConfigUpdate): Promise<SystemC
     body: JSON.stringify(payload),
   });
   return handleResponse<SystemConfig>(response);
+}
+
+export async function fetchSourceConnections(): Promise<SourceConnection[]> {
+  const response = await fetch(`${API_BASE_URL}/api/source/connections`);
+  return handleResponse<SourceConnection[]>(response);
+}
+
+export async function createSourceConnection(
+  payload: SourceConnectionCreatePayload,
+): Promise<SourceConnection> {
+  const response = await fetch(`${API_BASE_URL}/api/source/connections`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  return handleResponse<SourceConnection>(response);
+}
+
+export async function updateSourceConnection(
+  id: number,
+  payload: SourceConnectionUpdatePayload,
+): Promise<SourceConnection> {
+  const response = await fetch(`${API_BASE_URL}/api/source/connections/${id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  return handleResponse<SourceConnection>(response);
+}
+
+export async function deleteSourceConnection(id: number): Promise<void> {
+  const response = await fetch(`${API_BASE_URL}/api/source/connections/${id}`, {
+    method: 'DELETE',
+  });
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(message || 'Unable to delete connection');
+  }
+}
+
+export async function fetchFieldMappings(
+  connectionId: number,
+): Promise<SourceFieldMapping[]> {
+  const response = await fetch(
+    `${API_BASE_URL}/api/source/connections/${connectionId}/mappings`,
+  );
+  return handleResponse<SourceFieldMapping[]>(response);
+}
+
+export async function createFieldMapping(
+  connectionId: number,
+  payload: SourceFieldMappingPayload,
+): Promise<SourceFieldMapping> {
+  const response = await fetch(
+    `${API_BASE_URL}/api/source/connections/${connectionId}/mappings`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    },
+  );
+  return handleResponse<SourceFieldMapping>(response);
+}
+
+export async function updateFieldMapping(
+  connectionId: number,
+  mappingId: number,
+  payload: SourceFieldMappingPayload,
+): Promise<SourceFieldMapping> {
+  const response = await fetch(
+    `${API_BASE_URL}/api/source/connections/${connectionId}/mappings/${mappingId}`,
+    {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    },
+  );
+  return handleResponse<SourceFieldMapping>(response);
+}
+
+export async function deleteFieldMapping(
+  connectionId: number,
+  mappingId: number,
+): Promise<void> {
+  const response = await fetch(
+    `${API_BASE_URL}/api/source/connections/${connectionId}/mappings/${mappingId}`,
+    { method: 'DELETE' },
+  );
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(message || 'Unable to delete mapping');
+  }
+}
+
+export async function ingestSamples(
+  connectionId: number,
+  source_table: string,
+  source_field: string,
+  values: SourceSampleValuePayload[],
+): Promise<SourceSample[]> {
+  const response = await fetch(
+    `${API_BASE_URL}/api/source/connections/${connectionId}/samples`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ source_table, source_field, values }),
+    },
+  );
+  return handleResponse<SourceSample[]>(response);
+}
+
+export async function fetchMatchStatistics(
+  connectionId: number,
+): Promise<FieldMatchStats[]> {
+  const response = await fetch(
+    `${API_BASE_URL}/api/source/connections/${connectionId}/match-stats`,
+  );
+  return handleResponse<FieldMatchStats[]>(response);
+}
+
+export async function fetchUnmatchedValues(
+  connectionId: number,
+): Promise<UnmatchedValueRecord[]> {
+  const response = await fetch(
+    `${API_BASE_URL}/api/source/connections/${connectionId}/unmatched`,
+  );
+  return handleResponse<UnmatchedValueRecord[]>(response);
+}
+
+export async function createValueMapping(
+  connectionId: number,
+  payload: ValueMappingPayload,
+): Promise<ValueMapping> {
+  const response = await fetch(
+    `${API_BASE_URL}/api/source/connections/${connectionId}/value-mappings`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    },
+  );
+  return handleResponse<ValueMapping>(response);
+}
+
+export async function fetchConnectionValueMappings(
+  connectionId: number,
+): Promise<ValueMappingExpanded[]> {
+  const response = await fetch(
+    `${API_BASE_URL}/api/source/connections/${connectionId}/value-mappings`,
+  );
+  return handleResponse<ValueMappingExpanded[]>(response);
+}
+
+export async function fetchAllValueMappings(): Promise<ValueMappingExpanded[]> {
+  const response = await fetch(`${API_BASE_URL}/api/source/value-mappings`);
+  return handleResponse<ValueMappingExpanded[]>(response);
+}
+
+export async function updateValueMapping(
+  connectionId: number,
+  mappingId: number,
+  payload: ValueMappingUpdatePayload,
+): Promise<ValueMapping> {
+  const response = await fetch(
+    `${API_BASE_URL}/api/source/connections/${connectionId}/value-mappings/${mappingId}`,
+    {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    },
+  );
+  return handleResponse<ValueMapping>(response);
+}
+
+export async function deleteValueMapping(
+  connectionId: number,
+  mappingId: number,
+): Promise<void> {
+  const response = await fetch(
+    `${API_BASE_URL}/api/source/connections/${connectionId}/value-mappings/${mappingId}`,
+    {
+      method: 'DELETE',
+    },
+  );
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(message || 'Unable to delete value mapping');
+  }
 }

--- a/reviewer-ui/src/pages/ConnectionsPage.tsx
+++ b/reviewer-ui/src/pages/ConnectionsPage.tsx
@@ -1,0 +1,405 @@
+import { useCallback, useEffect, useState } from 'react';
+import DeleteRoundedIcon from '@mui/icons-material/DeleteRounded';
+import EditRoundedIcon from '@mui/icons-material/EditRounded';
+import AddCircleRoundedIcon from '@mui/icons-material/AddCircleRounded';
+import SaveRoundedIcon from '@mui/icons-material/SaveRounded';
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Grid,
+  IconButton,
+  Paper,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TextField,
+  Typography,
+} from '@mui/material';
+
+import {
+  createSourceConnection,
+  deleteSourceConnection,
+  fetchSourceConnections,
+  updateSourceConnection,
+} from '../api';
+import type {
+  SourceConnection,
+  SourceConnectionCreatePayload,
+  SourceConnectionUpdatePayload,
+  ToastMessage,
+} from '../types';
+
+interface ConnectionsPageProps {
+  onToast: (toast: ToastMessage) => void;
+}
+
+const emptyForm: SourceConnectionCreatePayload = {
+  name: '',
+  db_type: 'postgres',
+  host: '',
+  port: 5432,
+  database: '',
+  username: '',
+  password: '',
+  options: '',
+};
+
+const ConnectionsPage = ({ onToast }: ConnectionsPageProps) => {
+  const [connections, setConnections] = useState<SourceConnection[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [form, setForm] = useState<SourceConnectionCreatePayload>(emptyForm);
+  const [submitting, setSubmitting] = useState(false);
+  const [editing, setEditing] = useState<SourceConnection | null>(null);
+  const [editForm, setEditForm] = useState<SourceConnectionUpdatePayload>({});
+  const [deleteTarget, setDeleteTarget] = useState<SourceConnection | null>(null);
+
+  const loadConnections = useCallback(async () => {
+    setLoading(true);
+    try {
+      const records = await fetchSourceConnections();
+      setConnections(records);
+    } catch (error: unknown) {
+      console.error(error);
+      onToast({ type: 'error', content: 'Failed to load connections' });
+    } finally {
+      setLoading(false);
+    }
+  }, [onToast]);
+
+  useEffect(() => {
+    void loadConnections();
+  }, [loadConnections]);
+
+  const handleFormChange = (key: keyof SourceConnectionCreatePayload, value: string) => {
+    setForm((prev) => ({ ...prev, [key]: key === 'port' ? Number(value) : value }));
+  };
+
+  const handleCreate = async () => {
+    if (!form.name || !form.host || !form.database || !form.username) {
+      onToast({ type: 'error', content: 'Fill in all required fields.' });
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const payload: SourceConnectionCreatePayload = {
+        ...form,
+        options: form.options ? form.options : undefined,
+        password: form.password ? form.password : undefined,
+      };
+      const created = await createSourceConnection(payload);
+      setConnections((prev) => [...prev, created]);
+      setForm(emptyForm);
+      onToast({ type: 'success', content: 'Connection added' });
+    } catch (error: unknown) {
+      console.error(error);
+      onToast({ type: 'error', content: 'Unable to create connection' });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const openEdit = (connection: SourceConnection) => {
+    setEditing(connection);
+    setEditForm({
+      name: connection.name,
+      db_type: connection.db_type,
+      host: connection.host,
+      port: connection.port,
+      database: connection.database,
+      username: connection.username,
+      options: connection.options ?? '',
+      password: '',
+    });
+  };
+
+  const handleUpdate = async () => {
+    if (!editing) return;
+    try {
+      const payload: SourceConnectionUpdatePayload = {
+        ...editForm,
+        port: typeof editForm.port === 'string' ? Number(editForm.port) : editForm.port,
+      };
+      if (!payload.password) {
+        delete payload.password;
+      }
+      if (payload.options === '') {
+        payload.options = undefined;
+      }
+      const updated = await updateSourceConnection(editing.id, payload);
+      setConnections((prev) => prev.map((item) => (item.id === updated.id ? updated : item)));
+      onToast({ type: 'success', content: 'Connection updated' });
+    } catch (error: unknown) {
+      console.error(error);
+      onToast({ type: 'error', content: 'Unable to update connection' });
+      return;
+    } finally {
+      setEditing(null);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!deleteTarget) return;
+    try {
+      await deleteSourceConnection(deleteTarget.id);
+      setConnections((prev) => prev.filter((item) => item.id !== deleteTarget.id));
+      onToast({ type: 'success', content: 'Connection removed' });
+    } catch (error: unknown) {
+      console.error(error);
+      onToast({ type: 'error', content: 'Unable to delete connection' });
+    } finally {
+      setDeleteTarget(null);
+    }
+  };
+
+  const renderConnectionTable = () => {
+    if (!connections.length) {
+      return (
+        <Typography variant="body2" color="text.secondary" sx={{ p: 3 }}>
+          No connections configured yet. Add one to start ingesting source data.
+        </Typography>
+      );
+    }
+
+    return (
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell>Name</TableCell>
+            <TableCell>Type</TableCell>
+            <TableCell>Host</TableCell>
+            <TableCell>Database</TableCell>
+            <TableCell>User</TableCell>
+            <TableCell>Updated</TableCell>
+            <TableCell align="right">Actions</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {connections.map((connection) => (
+            <TableRow key={connection.id} hover>
+              <TableCell>{connection.name}</TableCell>
+              <TableCell>{connection.db_type}</TableCell>
+              <TableCell>{connection.host}:{connection.port}</TableCell>
+              <TableCell>{connection.database}</TableCell>
+              <TableCell>{connection.username}</TableCell>
+              <TableCell>{new Date(connection.updated_at).toLocaleString()}</TableCell>
+              <TableCell align="right">
+                <IconButton onClick={() => openEdit(connection)} aria-label="Edit">
+                  <EditRoundedIcon fontSize="small" />
+                </IconButton>
+                <IconButton onClick={() => setDeleteTarget(connection)} aria-label="Delete">
+                  <DeleteRoundedIcon fontSize="small" />
+                </IconButton>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    );
+  };
+
+  return (
+    <Stack spacing={4} component="section">
+      <Paper variant="outlined" sx={{ p: { xs: 3, md: 4 } }}>
+        <Stack spacing={2}>
+          <Box>
+            <Typography variant="h6" fontWeight={600} gutterBottom>
+              Register a source connection
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              Connection metadata is stored securely and used for field mapping, sampling, and reconciliation.
+            </Typography>
+          </Box>
+          <Grid container spacing={2} columns={{ xs: 1, sm: 6, md: 12 }}>
+            <Grid item xs={1} sm={3} md={4}>
+              <TextField
+                label="Connection Name"
+                value={form.name}
+                onChange={(event) => handleFormChange('name', event.target.value)}
+                fullWidth
+                required
+              />
+            </Grid>
+            <Grid item xs={1} sm={3} md={4}>
+              <TextField
+                label="Database Type"
+                value={form.db_type}
+                onChange={(event) => handleFormChange('db_type', event.target.value)}
+                fullWidth
+              />
+            </Grid>
+            <Grid item xs={1} sm={3} md={4}>
+              <TextField
+                label="Host"
+                value={form.host}
+                onChange={(event) => handleFormChange('host', event.target.value)}
+                fullWidth
+                required
+              />
+            </Grid>
+            <Grid item xs={1} sm={3} md={4}>
+              <TextField
+                label="Port"
+                type="number"
+                value={form.port}
+                onChange={(event) => handleFormChange('port', event.target.value)}
+                fullWidth
+              />
+            </Grid>
+            <Grid item xs={1} sm={3} md={4}>
+              <TextField
+                label="Database"
+                value={form.database}
+                onChange={(event) => handleFormChange('database', event.target.value)}
+                fullWidth
+                required
+              />
+            </Grid>
+            <Grid item xs={1} sm={3} md={4}>
+              <TextField
+                label="Username"
+                value={form.username}
+                onChange={(event) => handleFormChange('username', event.target.value)}
+                fullWidth
+                required
+              />
+            </Grid>
+            <Grid item xs={1} sm={3} md={4}>
+              <TextField
+                label="Password"
+                type="password"
+                value={form.password ?? ''}
+                onChange={(event) => handleFormChange('password', event.target.value)}
+                fullWidth
+              />
+            </Grid>
+            <Grid item xs={1} sm={6} md={8}>
+              <TextField
+                label="Options (JSON)"
+                value={form.options ?? ''}
+                onChange={(event) => handleFormChange('options', event.target.value)}
+                fullWidth
+                placeholder='{"sslmode":"require"}'
+              />
+            </Grid>
+            <Grid item xs={1} sm={6} md={12}>
+              <Button
+                variant="contained"
+                startIcon={<AddCircleRoundedIcon />}
+                disabled={submitting}
+                onClick={() => void handleCreate()}
+              >
+                {submitting ? 'Adding…' : 'Add Connection'}
+              </Button>
+            </Grid>
+          </Grid>
+        </Stack>
+      </Paper>
+
+      <Paper variant="outlined" sx={{ p: { xs: 3, md: 4 } }}>
+        <Typography variant="h6" fontWeight={600} gutterBottom>
+          Source connections
+        </Typography>
+        <Typography variant="body2" color="text.secondary" gutterBottom>
+          Edit or remove existing integrations. Deleting a connection removes associated field mappings, samples, and value mappings.
+        </Typography>
+        <TableContainer>
+          {loading ? (
+            <Typography variant="body2" color="text.secondary" sx={{ p: 3 }}>
+              Loading connections…
+            </Typography>
+          ) : (
+            renderConnectionTable()
+          )}
+        </TableContainer>
+      </Paper>
+
+      <Dialog open={Boolean(editing)} onClose={() => setEditing(null)} maxWidth="sm" fullWidth>
+        <DialogTitle>Edit connection</DialogTitle>
+        <DialogContent sx={{ pt: 2 }}>
+          <Stack spacing={2}>
+            <TextField
+              label="Connection Name"
+              value={editForm.name ?? ''}
+              onChange={(event) => setEditForm((prev) => ({ ...prev, name: event.target.value }))}
+              fullWidth
+            />
+            <TextField
+              label="Database Type"
+              value={editForm.db_type ?? ''}
+              onChange={(event) => setEditForm((prev) => ({ ...prev, db_type: event.target.value }))}
+              fullWidth
+            />
+            <TextField
+              label="Host"
+              value={editForm.host ?? ''}
+              onChange={(event) => setEditForm((prev) => ({ ...prev, host: event.target.value }))}
+              fullWidth
+            />
+            <TextField
+              label="Port"
+              type="number"
+              value={editForm.port ?? ''}
+              onChange={(event) => setEditForm((prev) => ({ ...prev, port: Number(event.target.value) }))}
+              fullWidth
+            />
+            <TextField
+              label="Database"
+              value={editForm.database ?? ''}
+              onChange={(event) => setEditForm((prev) => ({ ...prev, database: event.target.value }))}
+              fullWidth
+            />
+            <TextField
+              label="Username"
+              value={editForm.username ?? ''}
+              onChange={(event) => setEditForm((prev) => ({ ...prev, username: event.target.value }))}
+              fullWidth
+            />
+            <TextField
+              label="New Password"
+              type="password"
+              value={editForm.password ?? ''}
+              onChange={(event) => setEditForm((prev) => ({ ...prev, password: event.target.value }))}
+              fullWidth
+              helperText="Leave blank to keep the current secret"
+            />
+            <TextField
+              label="Options (JSON)"
+              value={editForm.options ?? ''}
+              onChange={(event) => setEditForm((prev) => ({ ...prev, options: event.target.value }))}
+              fullWidth
+            />
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setEditing(null)}>Cancel</Button>
+          <Button onClick={() => void handleUpdate()} variant="contained" startIcon={<SaveRoundedIcon />}>
+            Save
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Dialog open={Boolean(deleteTarget)} onClose={() => setDeleteTarget(null)}>
+        <DialogTitle>Delete connection</DialogTitle>
+        <DialogContent>
+          <Typography>Remove the “{deleteTarget?.name}” connection and its related records?</Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDeleteTarget(null)}>Cancel</Button>
+          <Button color="error" onClick={() => void handleDelete()} startIcon={<DeleteRoundedIcon />}>
+            Delete
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Stack>
+  );
+};
+
+export default ConnectionsPage;

--- a/reviewer-ui/src/pages/DashboardPage.tsx
+++ b/reviewer-ui/src/pages/DashboardPage.tsx
@@ -1,0 +1,551 @@
+import { useMemo, useState } from 'react';
+import EditRoundedIcon from '@mui/icons-material/EditRounded';
+import DeleteRoundedIcon from '@mui/icons-material/DeleteRounded';
+import SaveRoundedIcon from '@mui/icons-material/SaveRounded';
+import PlayArrowRoundedIcon from '@mui/icons-material/PlayArrowRounded';
+import AddCircleRoundedIcon from '@mui/icons-material/AddCircleRounded';
+import {
+  Alert,
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  FormControl,
+  Grid,
+  IconButton,
+  InputLabel,
+  MenuItem,
+  Paper,
+  Select,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TextField,
+  Typography,
+} from '@mui/material';
+
+import {
+  createCanonicalValue,
+  deleteCanonicalValue,
+  proposeMatch,
+  updateCanonicalValue,
+  updateConfig,
+} from '../api';
+import { useAppState } from '../state/AppStateContext';
+import type {
+  CanonicalValue,
+  CanonicalValueUpdatePayload,
+  MatchCandidate,
+  MatchResponse,
+  ToastMessage,
+} from '../types';
+
+interface DashboardPageProps {
+  onToast: (toast: ToastMessage) => void;
+}
+
+const DashboardPage = ({ onToast }: DashboardPageProps) => {
+  const { config, setConfig, canonicalValues, updateCanonicalValues, isLoading } = useAppState();
+  const [configDraft, setConfigDraft] = useState<Record<string, string>>({});
+  const [savingConfig, setSavingConfig] = useState(false);
+  const [matchInput, setMatchInput] = useState('');
+  const [matchDimension, setMatchDimension] = useState('');
+  const [matchResults, setMatchResults] = useState<MatchResponse | null>(null);
+  const [runningMatch, setRunningMatch] = useState(false);
+  const [creatingCanonical, setCreatingCanonical] = useState(false);
+  const [newCanonical, setNewCanonical] = useState<CanonicalValueUpdatePayload>({
+    dimension: '',
+    canonical_label: '',
+    description: '',
+  });
+  const [editingCanonical, setEditingCanonical] = useState<CanonicalValue | null>(null);
+  const [editDraft, setEditDraft] = useState<CanonicalValueUpdatePayload>({});
+  const [deleteTarget, setDeleteTarget] = useState<CanonicalValue | null>(null);
+
+  const availableDimensions = useMemo(() => {
+    const dimensionSet = new Set<string>();
+    canonicalValues.forEach((value) => dimensionSet.add(value.dimension));
+    if (config?.default_dimension) {
+      dimensionSet.add(config.default_dimension);
+    }
+    return Array.from(dimensionSet).sort();
+  }, [canonicalValues, config?.default_dimension]);
+
+  const handleConfigChange = (key: string, value: string) => {
+    setConfigDraft((draft) => ({ ...draft, [key]: value }));
+  };
+
+  const handleSaveConfig = async () => {
+    if (!config) return;
+    setSavingConfig(true);
+    try {
+      const payload: Record<string, string | number> = {};
+      Object.entries(configDraft).forEach(([key, value]) => {
+        if (value !== '') {
+          if (key === 'match_threshold' || key === 'top_k') {
+            payload[key] = Number(value);
+          } else {
+            payload[key] = value;
+          }
+        }
+      });
+      const updated = await updateConfig(payload);
+      setConfig(() => updated);
+      setConfigDraft({});
+      onToast({ type: 'success', content: 'Configuration updated' });
+    } catch (error: unknown) {
+      console.error(error);
+      onToast({ type: 'error', content: 'Unable to update configuration' });
+    } finally {
+      setSavingConfig(false);
+    }
+  };
+
+  const handleRunMatch = async () => {
+    if (!matchInput.trim()) {
+      onToast({ type: 'error', content: 'Enter a raw value to match.' });
+      return;
+    }
+    setRunningMatch(true);
+    try {
+      const response = await proposeMatch(matchInput.trim(), matchDimension || undefined);
+      setMatchResults(response);
+    } catch (error: unknown) {
+      console.error(error);
+      onToast({ type: 'error', content: 'Matching request failed' });
+    } finally {
+      setRunningMatch(false);
+    }
+  };
+
+  const handleCreateCanonical = async () => {
+    if (!newCanonical.dimension || !newCanonical.canonical_label) {
+      onToast({ type: 'error', content: 'Provide both dimension and label.' });
+      return;
+    }
+    setCreatingCanonical(true);
+    try {
+      const created = await createCanonicalValue(newCanonical);
+      updateCanonicalValues((values) => [...values, created]);
+      setNewCanonical({ dimension: '', canonical_label: '', description: '' });
+      onToast({ type: 'success', content: 'Canonical value added' });
+    } catch (error: unknown) {
+      console.error(error);
+      onToast({ type: 'error', content: 'Failed to add canonical value' });
+    } finally {
+      setCreatingCanonical(false);
+    }
+  };
+
+  const openEditDialog = (value: CanonicalValue) => {
+    setEditingCanonical(value);
+    setEditDraft({
+      dimension: value.dimension,
+      canonical_label: value.canonical_label,
+      description: value.description ?? '',
+    });
+  };
+
+  const handleUpdateCanonical = async () => {
+    if (!editingCanonical) return;
+    try {
+      const updated = await updateCanonicalValue(editingCanonical.id, editDraft);
+      updateCanonicalValues((values) =>
+        values.map((item) => (item.id === updated.id ? updated : item)),
+      );
+      onToast({ type: 'success', content: 'Canonical value updated' });
+    } catch (error: unknown) {
+      console.error(error);
+      onToast({ type: 'error', content: 'Unable to update canonical value' });
+      return;
+    } finally {
+      setEditingCanonical(null);
+    }
+  };
+
+  const handleDeleteCanonical = async () => {
+    if (!deleteTarget) return;
+    try {
+      await deleteCanonicalValue(deleteTarget.id);
+      updateCanonicalValues((values) => values.filter((item) => item.id !== deleteTarget.id));
+      onToast({ type: 'success', content: 'Canonical value removed' });
+    } catch (error: unknown) {
+      console.error(error);
+      onToast({ type: 'error', content: 'Unable to delete canonical value' });
+    } finally {
+      setDeleteTarget(null);
+    }
+  };
+
+  const renderMatches = (matches: MatchCandidate[]) => {
+    if (!matches.length) {
+      return (
+        <Alert severity="info" sx={{ mt: 2 }}>
+          No matches met the configured threshold.
+        </Alert>
+      );
+    }
+
+    return (
+      <TableContainer component={Paper} variant="outlined" sx={{ mt: 2 }}>
+        <Table size="small" aria-label="match results">
+          <TableHead>
+            <TableRow>
+              <TableCell>Label</TableCell>
+              <TableCell>Dimension</TableCell>
+              <TableCell>Score</TableCell>
+              <TableCell>Description</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {matches.map((match) => (
+              <TableRow key={match.canonical_id} hover>
+                <TableCell width="25%">{match.canonical_label}</TableCell>
+                <TableCell width="20%">{match.dimension}</TableCell>
+                <TableCell width="15%">{(match.score * 100).toFixed(1)}%</TableCell>
+                <TableCell>{match.description || '—'}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    );
+  };
+
+  if (isLoading) {
+    return (
+      <Paper elevation={0} variant="outlined" sx={{ p: 4, textAlign: 'center' }}>
+        <Typography variant="body1">Loading application state…</Typography>
+      </Paper>
+    );
+  }
+
+  return (
+    <Stack spacing={4} component="main">
+      <Paper variant="outlined" sx={{ p: { xs: 3, md: 4 } }}>
+        <Stack spacing={2}>
+          <Box>
+            <Typography variant="h6" fontWeight={600} gutterBottom>
+              Runtime Configuration
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              Updates persist instantly and drive the semantic matcher—no environment variables required.
+            </Typography>
+          </Box>
+          {config && (
+            <Grid container spacing={2} columns={{ xs: 1, sm: 6, md: 12 }}>
+              <Grid item xs={1} sm={3} md={6}>
+                <TextField
+                  label="Default Dimension"
+                  defaultValue={config.default_dimension}
+                  fullWidth
+                  onChange={(event) => handleConfigChange('default_dimension', event.target.value)}
+                />
+              </Grid>
+              <Grid item xs={1} sm={3} md={6}>
+                <TextField
+                  label="Match Threshold"
+                  type="number"
+                  inputProps={{ step: 0.05, min: 0, max: 1 }}
+                  defaultValue={config.match_threshold}
+                  fullWidth
+                  onChange={(event) => handleConfigChange('match_threshold', event.target.value)}
+                />
+              </Grid>
+              <Grid item xs={1} sm={3} md={6}>
+                <FormControl fullWidth>
+                  <InputLabel id="matcher-backend-label">Matcher Backend</InputLabel>
+                  <Select
+                    labelId="matcher-backend-label"
+                    label="Matcher Backend"
+                    defaultValue={config.matcher_backend}
+                    onChange={(event) => handleConfigChange('matcher_backend', event.target.value)}
+                  >
+                    <MenuItem value="embedding">Embedding based (default)</MenuItem>
+                    <MenuItem value="llm">LLM orchestration</MenuItem>
+                  </Select>
+                </FormControl>
+              </Grid>
+              <Grid item xs={1} sm={3} md={6}>
+                <TextField
+                  label="Embedding Model"
+                  defaultValue={config.embedding_model}
+                  fullWidth
+                  onChange={(event) => handleConfigChange('embedding_model', event.target.value)}
+                />
+              </Grid>
+              <Grid item xs={1} sm={3} md={6}>
+                <TextField
+                  label="LLM Model"
+                  placeholder="gpt-4o-mini"
+                  defaultValue={config.llm_model ?? ''}
+                  fullWidth
+                  onChange={(event) => handleConfigChange('llm_model', event.target.value)}
+                />
+              </Grid>
+              <Grid item xs={1} sm={3} md={6}>
+                <TextField
+                  label="LLM API Base URL"
+                  placeholder="https://api.openai.com/v1"
+                  defaultValue={config.llm_api_base ?? ''}
+                  fullWidth
+                  onChange={(event) => handleConfigChange('llm_api_base', event.target.value)}
+                />
+              </Grid>
+              <Grid item xs={1} sm={3} md={6}>
+                <TextField
+                  label="Top K Results"
+                  type="number"
+                  inputProps={{ min: 1, max: 20 }}
+                  defaultValue={config.top_k}
+                  fullWidth
+                  onChange={(event) => handleConfigChange('top_k', event.target.value)}
+                />
+              </Grid>
+            </Grid>
+          )}
+          <Box>
+            <Button
+              variant="contained"
+              onClick={() => void handleSaveConfig()}
+              disabled={savingConfig}
+              startIcon={<SaveRoundedIcon />}
+            >
+              {savingConfig ? 'Saving…' : 'Save Configuration'}
+            </Button>
+          </Box>
+        </Stack>
+      </Paper>
+
+      <Paper variant="outlined" sx={{ p: { xs: 3, md: 4 } }}>
+        <Stack spacing={3}>
+          <Box>
+            <Typography variant="h6" fontWeight={600} gutterBottom>
+              Semantic Match Playground
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              Experiment with live inputs to see how the matcher responds across dimensions.
+            </Typography>
+          </Box>
+          <Box
+            component="form"
+            onSubmit={(event) => {
+              event.preventDefault();
+              void handleRunMatch();
+            }}
+          >
+            <Stack spacing={2}>
+              <TextField
+                label="Raw value"
+                placeholder="Enter a raw data value to match"
+                multiline
+                minRows={3}
+                value={matchInput}
+                onChange={(event) => setMatchInput(event.target.value)}
+                fullWidth
+              />
+              <FormControl fullWidth>
+                <InputLabel id="dimension-label">Dimension (optional)</InputLabel>
+                <Select
+                  labelId="dimension-label"
+                  label="Dimension (optional)"
+                  value={matchDimension}
+                  onChange={(event) => setMatchDimension(event.target.value)}
+                >
+                  <MenuItem value="">Use default</MenuItem>
+                  {availableDimensions.map((dimension) => (
+                    <MenuItem key={dimension} value={dimension}>
+                      {dimension}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+              <Box>
+                <Button
+                  type="submit"
+                  variant="contained"
+                  disabled={runningMatch}
+                  startIcon={<PlayArrowRoundedIcon />}
+                >
+                  {runningMatch ? 'Matching…' : 'Run Match'}
+                </Button>
+              </Box>
+            </Stack>
+          </Box>
+          {matchResults && (
+            <Box>
+              <Divider sx={{ mb: 2 }} />
+              <Typography variant="subtitle1" fontWeight={600}>
+                Matches for “{matchResults.raw_text}”
+              </Typography>
+              {renderMatches(matchResults.matches)}
+            </Box>
+          )}
+        </Stack>
+      </Paper>
+
+      <Paper variant="outlined" sx={{ p: { xs: 3, md: 4 } }}>
+        <Stack spacing={3}>
+          <Box>
+            <Typography variant="h6" fontWeight={600} gutterBottom>
+              Canonical Library
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              Bootstrap reviewers with rich defaults and grow the knowledge base over time.
+            </Typography>
+          </Box>
+          <Box
+            component="form"
+            onSubmit={(event) => {
+              event.preventDefault();
+              void handleCreateCanonical();
+            }}
+          >
+            <Grid container spacing={2} columns={{ xs: 1, sm: 6, md: 12 }}>
+              <Grid item xs={1} sm={3} md={4}>
+                <TextField
+                  label="Dimension"
+                  value={newCanonical.dimension ?? ''}
+                  onChange={(event) =>
+                    setNewCanonical((draft) => ({
+                      ...draft,
+                      dimension: event.target.value,
+                    }))
+                  }
+                  fullWidth
+                  required
+                />
+              </Grid>
+              <Grid item xs={1} sm={3} md={4}>
+                <TextField
+                  label="Canonical Label"
+                  value={newCanonical.canonical_label ?? ''}
+                  onChange={(event) =>
+                    setNewCanonical((draft) => ({
+                      ...draft,
+                      canonical_label: event.target.value,
+                    }))
+                  }
+                  fullWidth
+                  required
+                />
+              </Grid>
+              <Grid item xs={1} sm={6} md={4}>
+                <TextField
+                  label="Description (optional)"
+                  value={newCanonical.description ?? ''}
+                  onChange={(event) =>
+                    setNewCanonical((draft) => ({
+                      ...draft,
+                      description: event.target.value,
+                    }))
+                  }
+                  fullWidth
+                  multiline
+                  minRows={2}
+                />
+              </Grid>
+              <Grid item xs={1} sm={6} md={12}>
+                <Button
+                  type="submit"
+                  variant="contained"
+                  disabled={creatingCanonical}
+                  startIcon={<AddCircleRoundedIcon />}
+                >
+                  {creatingCanonical ? 'Adding…' : 'Add Canonical Value'}
+                </Button>
+              </Grid>
+            </Grid>
+          </Box>
+          <TableContainer component={Paper} variant="outlined">
+            <Table size="small" aria-label="canonical values">
+              <TableHead>
+                <TableRow>
+                  <TableCell>Label</TableCell>
+                  <TableCell>Dimension</TableCell>
+                  <TableCell>Description</TableCell>
+                  <TableCell align="right">Actions</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {canonicalValues.map((value) => (
+                  <TableRow key={`${value.dimension}-${value.id}`} hover>
+                    <TableCell width="30%">{value.canonical_label}</TableCell>
+                    <TableCell width="25%">{value.dimension}</TableCell>
+                    <TableCell>{value.description || '—'}</TableCell>
+                    <TableCell align="right" sx={{ whiteSpace: 'nowrap' }}>
+                      <IconButton aria-label="Edit" onClick={() => openEditDialog(value)}>
+                        <EditRoundedIcon fontSize="small" />
+                      </IconButton>
+                      <IconButton aria-label="Delete" onClick={() => setDeleteTarget(value)}>
+                        <DeleteRoundedIcon fontSize="small" />
+                      </IconButton>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </Stack>
+      </Paper>
+
+      <Dialog open={Boolean(editingCanonical)} onClose={() => setEditingCanonical(null)} maxWidth="sm" fullWidth>
+        <DialogTitle>Edit canonical value</DialogTitle>
+        <DialogContent sx={{ pt: 2 }}>
+          <Stack spacing={2}>
+            <TextField
+              label="Dimension"
+              value={editDraft.dimension ?? ''}
+              onChange={(event) => setEditDraft((draft) => ({ ...draft, dimension: event.target.value }))}
+              fullWidth
+            />
+            <TextField
+              label="Canonical Label"
+              value={editDraft.canonical_label ?? ''}
+              onChange={(event) => setEditDraft((draft) => ({ ...draft, canonical_label: event.target.value }))}
+              fullWidth
+            />
+            <TextField
+              label="Description"
+              value={editDraft.description ?? ''}
+              onChange={(event) => setEditDraft((draft) => ({ ...draft, description: event.target.value }))}
+              fullWidth
+              multiline
+              minRows={3}
+            />
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setEditingCanonical(null)}>Cancel</Button>
+          <Button onClick={() => void handleUpdateCanonical()} variant="contained" startIcon={<SaveRoundedIcon />}>
+            Save
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Dialog open={Boolean(deleteTarget)} onClose={() => setDeleteTarget(null)}>
+        <DialogTitle>Remove canonical value</DialogTitle>
+        <DialogContent>
+          <Typography>
+            Delete “{deleteTarget?.canonical_label}” from the {deleteTarget?.dimension} dimension?
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDeleteTarget(null)}>Cancel</Button>
+          <Button color="error" onClick={() => void handleDeleteCanonical()} startIcon={<DeleteRoundedIcon />}>
+            Delete
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Stack>
+  );
+};
+
+export default DashboardPage;

--- a/reviewer-ui/src/pages/FieldMappingsPage.tsx
+++ b/reviewer-ui/src/pages/FieldMappingsPage.tsx
@@ -1,0 +1,500 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import AddCircleRoundedIcon from '@mui/icons-material/AddCircleRounded';
+import DeleteRoundedIcon from '@mui/icons-material/DeleteRounded';
+import EditRoundedIcon from '@mui/icons-material/EditRounded';
+import SaveRoundedIcon from '@mui/icons-material/SaveRounded';
+import UploadRoundedIcon from '@mui/icons-material/UploadRounded';
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  Grid,
+  IconButton,
+  InputLabel,
+  MenuItem,
+  Paper,
+  Select,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TextField,
+  Typography,
+} from '@mui/material';
+
+import {
+  createFieldMapping,
+  deleteFieldMapping,
+  fetchFieldMappings,
+  fetchSourceConnections,
+  ingestSamples,
+  updateFieldMapping,
+} from '../api';
+import { useAppState } from '../state/AppStateContext';
+import type {
+  SourceConnection,
+  SourceFieldMapping,
+  SourceFieldMappingPayload,
+  SourceSampleValuePayload,
+  ToastMessage,
+} from '../types';
+
+interface FieldMappingsPageProps {
+  onToast: (toast: ToastMessage) => void;
+}
+
+const initialMapping: SourceFieldMappingPayload = {
+  source_table: '',
+  source_field: '',
+  ref_dimension: '',
+  description: '',
+};
+
+const FieldMappingsPage = ({ onToast }: FieldMappingsPageProps) => {
+  const { canonicalValues } = useAppState();
+  const [connections, setConnections] = useState<SourceConnection[]>([]);
+  const [selectedConnectionId, setSelectedConnectionId] = useState<number | ''>('');
+  const [mappings, setMappings] = useState<SourceFieldMapping[]>([]);
+  const [loadingMappings, setLoadingMappings] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [form, setForm] = useState<SourceFieldMappingPayload>(initialMapping);
+  const [editing, setEditing] = useState<SourceFieldMapping | null>(null);
+  const [editForm, setEditForm] = useState<SourceFieldMappingPayload>(initialMapping);
+  const [deleteTarget, setDeleteTarget] = useState<SourceFieldMapping | null>(null);
+  const [sampleTable, setSampleTable] = useState('');
+  const [sampleField, setSampleField] = useState('');
+  const [sampleDimension, setSampleDimension] = useState('');
+  const [sampleInput, setSampleInput] = useState('');
+  const [ingesting, setIngesting] = useState(false);
+
+  const availableDimensions = useMemo(() => {
+    const set = new Set<string>();
+    canonicalValues.forEach((value) => set.add(value.dimension));
+    return Array.from(set).sort();
+  }, [canonicalValues]);
+
+  const loadConnections = useCallback(async () => {
+    try {
+      const records = await fetchSourceConnections();
+      setConnections(records);
+      if (!selectedConnectionId && records.length) {
+        setSelectedConnectionId(records[0].id);
+      }
+    } catch (error) {
+      console.error(error);
+      onToast({ type: 'error', content: 'Failed to load connections' });
+    }
+  }, [onToast, selectedConnectionId]);
+
+  const loadMappings = useCallback(async (connectionId: number) => {
+    setLoadingMappings(true);
+    try {
+      const records = await fetchFieldMappings(connectionId);
+      setMappings(records);
+    } catch (error) {
+      console.error(error);
+      onToast({ type: 'error', content: 'Failed to load field mappings' });
+    } finally {
+      setLoadingMappings(false);
+    }
+  }, [onToast]);
+
+  useEffect(() => {
+    void loadConnections();
+  }, [loadConnections]);
+
+  useEffect(() => {
+    if (selectedConnectionId) {
+      void loadMappings(selectedConnectionId);
+    } else {
+      setMappings([]);
+    }
+  }, [selectedConnectionId, loadMappings]);
+
+  const handleCreate = async () => {
+    if (!selectedConnectionId) {
+      onToast({ type: 'error', content: 'Select a connection first.' });
+      return;
+    }
+    if (!form.source_table || !form.source_field || !form.ref_dimension) {
+      onToast({ type: 'error', content: 'Provide table, field, and dimension.' });
+      return;
+    }
+    setCreating(true);
+    try {
+      const created = await createFieldMapping(selectedConnectionId, form);
+      setMappings((prev) => [...prev, created]);
+      setForm(initialMapping);
+      onToast({ type: 'success', content: 'Field mapping created' });
+    } catch (error) {
+      console.error(error);
+      onToast({ type: 'error', content: 'Unable to create field mapping' });
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const openEdit = (mapping: SourceFieldMapping) => {
+    setEditing(mapping);
+    setEditForm({
+      source_table: mapping.source_table,
+      source_field: mapping.source_field,
+      ref_dimension: mapping.ref_dimension,
+      description: mapping.description ?? '',
+    });
+  };
+
+  const handleUpdate = async () => {
+    if (!editing || !selectedConnectionId) return;
+    try {
+      const updated = await updateFieldMapping(selectedConnectionId, editing.id, editForm);
+      setMappings((prev) => prev.map((item) => (item.id === updated.id ? updated : item)));
+      onToast({ type: 'success', content: 'Field mapping updated' });
+    } catch (error) {
+      console.error(error);
+      onToast({ type: 'error', content: 'Unable to update mapping' });
+      return;
+    } finally {
+      setEditing(null);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!deleteTarget || !selectedConnectionId) return;
+    try {
+      await deleteFieldMapping(selectedConnectionId, deleteTarget.id);
+      setMappings((prev) => prev.filter((item) => item.id !== deleteTarget.id));
+      onToast({ type: 'success', content: 'Field mapping removed' });
+    } catch (error) {
+      console.error(error);
+      onToast({ type: 'error', content: 'Unable to delete mapping' });
+    } finally {
+      setDeleteTarget(null);
+    }
+  };
+
+  const parseSampleInput = (): SourceSampleValuePayload[] => {
+    return sampleInput
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => {
+        const [raw, count] = line.split(',');
+        return {
+          raw_value: raw.trim(),
+          occurrence_count: count ? Number(count.trim()) || 1 : 1,
+          dimension: sampleDimension || undefined,
+        };
+      });
+  };
+
+  const handleIngest = async () => {
+    if (!selectedConnectionId) {
+      onToast({ type: 'error', content: 'Select a connection first.' });
+      return;
+    }
+    if (!sampleTable || !sampleField) {
+      onToast({ type: 'error', content: 'Provide source table and field.' });
+      return;
+    }
+    const values = parseSampleInput();
+    if (!values.length) {
+      onToast({ type: 'error', content: 'Provide at least one value.' });
+      return;
+    }
+    setIngesting(true);
+    try {
+      await ingestSamples(selectedConnectionId, sampleTable, sampleField, values);
+      onToast({ type: 'success', content: 'Sample values ingested' });
+      setSampleInput('');
+    } catch (error) {
+      console.error(error);
+      onToast({ type: 'error', content: 'Failed to ingest sample values' });
+    } finally {
+      setIngesting(false);
+    }
+  };
+
+  return (
+    <Stack spacing={4} component="section">
+      <Paper variant="outlined" sx={{ p: { xs: 3, md: 4 } }}>
+        <Stack spacing={2}>
+          <Box sx={{ display: 'flex', flexDirection: { xs: 'column', md: 'row' }, gap: 2 }}>
+            <Box sx={{ flexGrow: 1 }}>
+              <Typography variant="h6" fontWeight={600} gutterBottom>
+                Map source fields to reference dimensions
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                Define which source fields feed each reference dataset. These mappings power downstream match statistics and reviewer workflows.
+              </Typography>
+            </Box>
+            <FormControl size="small" sx={{ minWidth: 220 }}>
+              <InputLabel id="connection-select-label">Connection</InputLabel>
+              <Select
+                labelId="connection-select-label"
+                label="Connection"
+                value={selectedConnectionId}
+                onChange={(event) => setSelectedConnectionId(Number(event.target.value))}
+              >
+                {connections.map((connection) => (
+                  <MenuItem key={connection.id} value={connection.id}>
+                    {connection.name}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          </Box>
+
+          <Grid container spacing={2} columns={{ xs: 1, sm: 6, md: 12 }}>
+            <Grid item xs={1} sm={3} md={3}>
+              <TextField
+                label="Source table"
+                value={form.source_table}
+                onChange={(event) => setForm((prev) => ({ ...prev, source_table: event.target.value }))}
+                fullWidth
+                required
+              />
+            </Grid>
+            <Grid item xs={1} sm={3} md={3}>
+              <TextField
+                label="Source field"
+                value={form.source_field}
+                onChange={(event) => setForm((prev) => ({ ...prev, source_field: event.target.value }))}
+                fullWidth
+                required
+              />
+            </Grid>
+            <Grid item xs={1} sm={3} md={3}>
+              <FormControl fullWidth>
+                <InputLabel id="dimension-select-label">Reference dimension</InputLabel>
+                <Select
+                  labelId="dimension-select-label"
+                  label="Reference dimension"
+                  value={form.ref_dimension}
+                  onChange={(event) => setForm((prev) => ({ ...prev, ref_dimension: event.target.value }))}
+                >
+                  {availableDimensions.map((dimension) => (
+                    <MenuItem key={dimension} value={dimension}>
+                      {dimension}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            </Grid>
+            <Grid item xs={1} sm={6} md={3}>
+              <TextField
+                label="Description"
+                value={form.description ?? ''}
+                onChange={(event) => setForm((prev) => ({ ...prev, description: event.target.value }))}
+                fullWidth
+              />
+            </Grid>
+            <Grid item xs={1} sm={6} md={12}>
+              <Button
+                variant="contained"
+                startIcon={<AddCircleRoundedIcon />}
+                disabled={creating || !selectedConnectionId}
+                onClick={() => void handleCreate()}
+              >
+                {creating ? 'Creating…' : 'Create mapping'}
+              </Button>
+            </Grid>
+          </Grid>
+        </Stack>
+      </Paper>
+
+      <Paper variant="outlined" sx={{ p: { xs: 3, md: 4 } }}>
+        <Typography variant="h6" fontWeight={600} gutterBottom>
+          Configured field mappings
+        </Typography>
+        <Typography variant="body2" color="text.secondary" gutterBottom>
+          Manage how source data flows into the reference data hub. These mappings drive sample ingestion, suggestions, and reconciliation insights.
+        </Typography>
+        <TableContainer>
+          {loadingMappings ? (
+            <Typography variant="body2" color="text.secondary" sx={{ p: 3 }}>
+              Loading mappings…
+            </Typography>
+          ) : mappings.length ? (
+            <Table size="small">
+              <TableHead>
+                <TableRow>
+                  <TableCell>Table</TableCell>
+                  <TableCell>Field</TableCell>
+                  <TableCell>Dimension</TableCell>
+                  <TableCell>Description</TableCell>
+                  <TableCell align="right">Actions</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {mappings.map((mapping) => (
+                  <TableRow key={mapping.id} hover>
+                    <TableCell>{mapping.source_table}</TableCell>
+                    <TableCell>{mapping.source_field}</TableCell>
+                    <TableCell>{mapping.ref_dimension}</TableCell>
+                    <TableCell>{mapping.description || '—'}</TableCell>
+                    <TableCell align="right">
+                      <IconButton onClick={() => openEdit(mapping)} aria-label="Edit mapping">
+                        <EditRoundedIcon fontSize="small" />
+                      </IconButton>
+                      <IconButton onClick={() => setDeleteTarget(mapping)} aria-label="Delete mapping">
+                        <DeleteRoundedIcon fontSize="small" />
+                      </IconButton>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          ) : (
+            <Typography variant="body2" color="text.secondary" sx={{ p: 3 }}>
+              No mappings defined yet. Add one above to get started.
+            </Typography>
+          )}
+        </TableContainer>
+      </Paper>
+
+      <Paper variant="outlined" sx={{ p: { xs: 3, md: 4 } }}>
+        <Stack spacing={2}>
+          <Box>
+            <Typography variant="h6" fontWeight={600} gutterBottom>
+              Ingest sample values
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              Paste raw values (optionally with counts) to simulate pulling data from the source. Each line accepts <code>value,count</code>.
+            </Typography>
+          </Box>
+          <Grid container spacing={2} columns={{ xs: 1, sm: 6, md: 12 }}>
+            <Grid item xs={1} sm={3} md={3}>
+              <TextField
+                label="Source table"
+                value={sampleTable}
+                onChange={(event) => setSampleTable(event.target.value)}
+                fullWidth
+              />
+            </Grid>
+            <Grid item xs={1} sm={3} md={3}>
+              <TextField
+                label="Source field"
+                value={sampleField}
+                onChange={(event) => setSampleField(event.target.value)}
+                fullWidth
+              />
+            </Grid>
+            <Grid item xs={1} sm={3} md={3}>
+              <FormControl fullWidth>
+                <InputLabel id="sample-dimension-label">Dimension (optional)</InputLabel>
+                <Select
+                  labelId="sample-dimension-label"
+                  label="Dimension (optional)"
+                  value={sampleDimension}
+                  onChange={(event) => setSampleDimension(event.target.value)}
+                >
+                  <MenuItem value="">Auto-detect</MenuItem>
+                  {availableDimensions.map((dimension) => (
+                    <MenuItem key={dimension} value={dimension}>
+                      {dimension}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            </Grid>
+            <Grid item xs={1} sm={6} md={12}>
+              <TextField
+                label="Raw values"
+                value={sampleInput}
+                onChange={(event) => setSampleInput(event.target.value)}
+                fullWidth
+                multiline
+                minRows={4}
+                placeholder={`Single
+Married,12
+Divorced,3`}
+              />
+            </Grid>
+            <Grid item xs={1} sm={6} md={12}>
+              <Button
+                variant="contained"
+                startIcon={<UploadRoundedIcon />}
+                disabled={ingesting || !selectedConnectionId}
+                onClick={() => void handleIngest()}
+              >
+                {ingesting ? 'Ingesting…' : 'Ingest sample values'}
+              </Button>
+            </Grid>
+          </Grid>
+        </Stack>
+      </Paper>
+
+      <Dialog open={Boolean(editing)} onClose={() => setEditing(null)} maxWidth="sm" fullWidth>
+        <DialogTitle>Edit mapping</DialogTitle>
+        <DialogContent sx={{ pt: 2 }}>
+          <Stack spacing={2}>
+            <TextField
+              label="Source table"
+              value={editForm.source_table}
+              onChange={(event) => setEditForm((prev) => ({ ...prev, source_table: event.target.value }))}
+              fullWidth
+            />
+            <TextField
+              label="Source field"
+              value={editForm.source_field}
+              onChange={(event) => setEditForm((prev) => ({ ...prev, source_field: event.target.value }))}
+              fullWidth
+            />
+            <FormControl fullWidth>
+              <InputLabel id="edit-dimension-label">Reference dimension</InputLabel>
+              <Select
+                labelId="edit-dimension-label"
+                label="Reference dimension"
+                value={editForm.ref_dimension}
+                onChange={(event) => setEditForm((prev) => ({ ...prev, ref_dimension: event.target.value }))}
+              >
+                {availableDimensions.map((dimension) => (
+                  <MenuItem key={dimension} value={dimension}>
+                    {dimension}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+            <TextField
+              label="Description"
+              value={editForm.description ?? ''}
+              onChange={(event) => setEditForm((prev) => ({ ...prev, description: event.target.value }))}
+              fullWidth
+            />
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setEditing(null)}>Cancel</Button>
+          <Button onClick={() => void handleUpdate()} variant="contained" startIcon={<SaveRoundedIcon />}>
+            Save
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Dialog open={Boolean(deleteTarget)} onClose={() => setDeleteTarget(null)}>
+        <DialogTitle>Delete mapping</DialogTitle>
+        <DialogContent>
+          <Typography>
+            Remove the mapping for “{deleteTarget?.source_table}.{deleteTarget?.source_field}”?
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDeleteTarget(null)}>Cancel</Button>
+          <Button color="error" onClick={() => void handleDelete()} startIcon={<DeleteRoundedIcon />}>
+            Delete
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Stack>
+  );
+};
+
+export default FieldMappingsPage;

--- a/reviewer-ui/src/pages/MappingHistoryPage.tsx
+++ b/reviewer-ui/src/pages/MappingHistoryPage.tsx
@@ -1,0 +1,334 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import DeleteRoundedIcon from '@mui/icons-material/DeleteRounded';
+import EditRoundedIcon from '@mui/icons-material/EditRounded';
+import SaveRoundedIcon from '@mui/icons-material/SaveRounded';
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Paper,
+  Select,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TextField,
+  Typography,
+} from '@mui/material';
+
+import {
+  deleteValueMapping,
+  fetchAllValueMappings,
+  fetchConnectionValueMappings,
+  fetchSourceConnections,
+  updateValueMapping,
+} from '../api';
+import { useAppState } from '../state/AppStateContext';
+import type {
+  CanonicalValue,
+  SourceConnection,
+  ToastMessage,
+  ValueMappingExpanded,
+  ValueMappingUpdatePayload,
+} from '../types';
+
+interface MappingHistoryPageProps {
+  onToast: (toast: ToastMessage) => void;
+}
+
+const MappingHistoryPage = ({ onToast }: MappingHistoryPageProps) => {
+  const { canonicalValues } = useAppState();
+  const [connections, setConnections] = useState<SourceConnection[]>([]);
+  const [selectedConnection, setSelectedConnection] = useState<number | 'all'>('all');
+  const [mappings, setMappings] = useState<ValueMappingExpanded[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [editing, setEditing] = useState<ValueMappingExpanded | null>(null);
+  const [editForm, setEditForm] = useState<ValueMappingUpdatePayload>({});
+  const [deleteTarget, setDeleteTarget] = useState<ValueMappingExpanded | null>(null);
+
+  const canonicalByDimension = useMemo(() => {
+    const map = new Map<string, CanonicalValue[]>();
+    canonicalValues.forEach((value) => {
+      const list = map.get(value.dimension) ?? [];
+      list.push(value);
+      map.set(value.dimension, list);
+    });
+    map.forEach((list) => list.sort((a, b) => a.canonical_label.localeCompare(b.canonical_label)));
+    return map;
+  }, [canonicalValues]);
+
+  const loadConnections = useCallback(async () => {
+    try {
+      const records = await fetchSourceConnections();
+      setConnections(records);
+    } catch (error) {
+      console.error(error);
+      onToast({ type: 'error', content: 'Failed to load connections' });
+    }
+  }, [onToast]);
+
+  const loadMappings = useCallback(async (connection: number | 'all') => {
+    setLoading(true);
+    try {
+      const records = connection === 'all'
+        ? await fetchAllValueMappings()
+        : await fetchConnectionValueMappings(connection);
+      setMappings(records);
+    } catch (error) {
+      console.error(error);
+      onToast({ type: 'error', content: 'Unable to load value mappings' });
+    } finally {
+      setLoading(false);
+    }
+  }, [onToast]);
+
+  useEffect(() => {
+    void loadConnections();
+  }, [loadConnections]);
+
+  useEffect(() => {
+    void loadMappings(selectedConnection);
+  }, [selectedConnection, loadMappings]);
+
+  const openEdit = (mapping: ValueMappingExpanded) => {
+    setEditing(mapping);
+    setEditForm({
+      canonical_id: mapping.canonical_id,
+      status: mapping.status,
+      confidence: mapping.confidence ?? undefined,
+      notes: mapping.notes ?? '',
+    });
+  };
+
+  const handleUpdate = async () => {
+    if (!editing) return;
+    try {
+      const payload: ValueMappingUpdatePayload = {
+        ...editForm,
+        confidence:
+          typeof editForm.confidence === 'number' ? editForm.confidence : undefined,
+        notes: editForm.notes === '' ? undefined : editForm.notes,
+      };
+      const updated = await updateValueMapping(editing.source_connection_id, editing.id, payload);
+      const canonical = canonicalValues.find((value) => value.id === updated.canonical_id);
+      setMappings((prev) =>
+        prev.map((item) =>
+          item.id === updated.id
+            ? {
+                ...item,
+                canonical_id: updated.canonical_id,
+                status: updated.status,
+                confidence: updated.confidence ?? undefined,
+                suggested_label: updated.suggested_label ?? undefined,
+                notes: updated.notes ?? undefined,
+                updated_at: updated.updated_at,
+                canonical_label: canonical?.canonical_label ?? item.canonical_label,
+                ref_dimension: canonical?.dimension ?? item.ref_dimension,
+              }
+            : item,
+        ),
+      );
+      onToast({ type: 'success', content: 'Mapping updated' });
+    } catch (error) {
+      console.error(error);
+      onToast({ type: 'error', content: 'Unable to update mapping' });
+      return;
+    } finally {
+      setEditing(null);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!deleteTarget) return;
+    try {
+      await deleteValueMapping(deleteTarget.source_connection_id, deleteTarget.id);
+      setMappings((prev) => prev.filter((item) => item.id !== deleteTarget.id));
+      onToast({ type: 'success', content: 'Mapping deleted' });
+    } catch (error) {
+      console.error(error);
+      onToast({ type: 'error', content: 'Unable to delete mapping' });
+    } finally {
+      setDeleteTarget(null);
+    }
+  };
+
+  return (
+    <Stack spacing={4} component="section">
+      <Paper variant="outlined" sx={{ p: { xs: 3, md: 4 } }}>
+        <Stack spacing={2}>
+          <Box sx={{ display: 'flex', flexDirection: { xs: 'column', md: 'row' }, gap: 2 }}>
+            <Box sx={{ flexGrow: 1 }}>
+              <Typography variant="h6" fontWeight={600} gutterBottom>
+                Mapping history
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                Review every approved mapping across your reference datasets. Update or retire mappings as source systems evolve.
+              </Typography>
+            </Box>
+            <FormControl size="small" sx={{ minWidth: 220 }}>
+              <InputLabel id="history-connection-label">Connection</InputLabel>
+              <Select
+                labelId="history-connection-label"
+                label="Connection"
+                value={selectedConnection}
+                onChange={(event) => {
+                  const value = event.target.value;
+                  setSelectedConnection(value === 'all' ? 'all' : Number(value));
+                }}
+              >
+                <MenuItem value="all">All connections</MenuItem>
+                {connections.map((connection) => (
+                  <MenuItem key={connection.id} value={connection.id}>
+                    {connection.name}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          </Box>
+          {loading && <Typography variant="body2">Loading mappings…</Typography>}
+        </Stack>
+      </Paper>
+
+      <Paper variant="outlined" sx={{ p: { xs: 0 } }}>
+        <TableContainer>
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>Connection</TableCell>
+                <TableCell>Source</TableCell>
+                <TableCell>Canonical value</TableCell>
+                <TableCell>Dimension</TableCell>
+                <TableCell>Status</TableCell>
+                <TableCell>Confidence</TableCell>
+                <TableCell>Updated</TableCell>
+                <TableCell align="right">Actions</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {mappings.map((mapping) => (
+                <TableRow key={mapping.id} hover>
+                  <TableCell>
+                    {connections.find((conn) => conn.id === mapping.source_connection_id)?.name || mapping.source_connection_id}
+                  </TableCell>
+                  <TableCell>{mapping.source_table}.{mapping.source_field}</TableCell>
+                  <TableCell>{mapping.canonical_label}</TableCell>
+                  <TableCell>{mapping.ref_dimension}</TableCell>
+                  <TableCell>{mapping.status}</TableCell>
+                  <TableCell>{mapping.confidence != null ? `${(mapping.confidence * 100).toFixed(0)}%` : '—'}</TableCell>
+                  <TableCell>{new Date(mapping.updated_at).toLocaleString()}</TableCell>
+                  <TableCell align="right">
+                    <Button size="small" startIcon={<EditRoundedIcon fontSize="small" />} onClick={() => openEdit(mapping)}>
+                      Edit
+                    </Button>
+                    <Button
+                      size="small"
+                      color="error"
+                      startIcon={<DeleteRoundedIcon fontSize="small" />}
+                      onClick={() => setDeleteTarget(mapping)}
+                    >
+                      Delete
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+              {!mappings.length && !loading && (
+                <TableRow>
+                  <TableCell colSpan={8} align="center">
+                    <Typography variant="body2" color="text.secondary">
+                      No mappings recorded yet.
+                    </Typography>
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </Paper>
+
+      <Dialog open={Boolean(editing)} onClose={() => setEditing(null)} maxWidth="sm" fullWidth>
+        <DialogTitle>Edit mapping</DialogTitle>
+        <DialogContent sx={{ pt: 2 }}>
+          <Stack spacing={2}>
+            <FormControl fullWidth>
+              <InputLabel id="edit-canonical-label">Canonical value</InputLabel>
+              <Select
+                labelId="edit-canonical-label"
+                label="Canonical value"
+                value={editForm.canonical_id ?? ''}
+                onChange={(event) => setEditForm((prev) => ({ ...prev, canonical_id: Number(event.target.value) }))}
+              >
+                {editing &&
+                  (canonicalByDimension.get(editing.ref_dimension) ?? []).map((canonical) => (
+                    <MenuItem key={canonical.id} value={canonical.id}>
+                      {canonical.canonical_label}
+                    </MenuItem>
+                  ))}
+              </Select>
+            </FormControl>
+            <FormControl fullWidth>
+              <InputLabel id="edit-status-label">Status</InputLabel>
+              <Select
+                labelId="edit-status-label"
+                label="Status"
+                value={editForm.status ?? 'approved'}
+                onChange={(event) => setEditForm((prev) => ({ ...prev, status: event.target.value }))}
+              >
+                <MenuItem value="approved">Approved</MenuItem>
+                <MenuItem value="pending">Pending</MenuItem>
+                <MenuItem value="retired">Retired</MenuItem>
+              </Select>
+            </FormControl>
+            <TextField
+              label="Confidence (0-1)"
+              type="number"
+              inputProps={{ min: 0, max: 1, step: 0.05 }}
+              value={editForm.confidence ?? ''}
+              onChange={(event) => setEditForm((prev) => ({ ...prev, confidence: event.target.value === '' ? undefined : Number(event.target.value) }))}
+              fullWidth
+            />
+            <TextField
+              label="Notes"
+              value={editForm.notes ?? ''}
+              onChange={(event) => setEditForm((prev) => ({ ...prev, notes: event.target.value }))}
+              fullWidth
+              multiline
+              minRows={3}
+            />
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setEditing(null)}>Cancel</Button>
+          <Button onClick={() => void handleUpdate()} variant="contained" startIcon={<SaveRoundedIcon />}>
+            Save
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Dialog open={Boolean(deleteTarget)} onClose={() => setDeleteTarget(null)}>
+        <DialogTitle>Delete mapping</DialogTitle>
+        <DialogContent>
+          <Typography>
+            Remove the mapping for “{deleteTarget?.raw_value}” from {deleteTarget?.source_table}.{deleteTarget?.source_field}?
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDeleteTarget(null)}>Cancel</Button>
+          <Button color="error" onClick={() => void handleDelete()} startIcon={<DeleteRoundedIcon />}>
+            Delete
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Stack>
+  );
+};
+
+export default MappingHistoryPage;

--- a/reviewer-ui/src/pages/MatchInsightsPage.tsx
+++ b/reviewer-ui/src/pages/MatchInsightsPage.tsx
@@ -1,0 +1,204 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import InsightsRoundedIcon from '@mui/icons-material/InsightsRounded';
+import {
+  Box,
+  Chip,
+  FormControl,
+  InputLabel,
+  LinearProgress,
+  MenuItem,
+  Paper,
+  Select,
+  Stack,
+  Typography,
+} from '@mui/material';
+
+import { fetchMatchStatistics, fetchSourceConnections } from '../api';
+import type { FieldMatchStats, MatchCandidate, SourceConnection, ToastMessage } from '../types';
+
+interface MatchInsightsPageProps {
+  onToast: (toast: ToastMessage) => void;
+}
+
+const renderSuggestions = (suggestions: MatchCandidate[]) => {
+  if (!suggestions.length) {
+    return <Typography variant="body2">No suggestions above the relaxed threshold.</Typography>;
+  }
+
+  return (
+    <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+      {suggestions.map((candidate) => (
+        <Chip
+          key={candidate.canonical_id}
+          label={`${candidate.canonical_label} (${(candidate.score * 100).toFixed(0)}%)`}
+          size="small"
+          color={candidate.score >= 0.6 ? 'primary' : 'default'}
+        />
+      ))}
+    </Stack>
+  );
+};
+
+const MatchInsightsPage = ({ onToast }: MatchInsightsPageProps) => {
+  const [connections, setConnections] = useState<SourceConnection[]>([]);
+  const [selectedConnectionId, setSelectedConnectionId] = useState<number | ''>('');
+  const [stats, setStats] = useState<FieldMatchStats[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const loadConnections = useCallback(async () => {
+    try {
+      const records = await fetchSourceConnections();
+      setConnections(records);
+      if (!selectedConnectionId && records.length) {
+        setSelectedConnectionId(records[0].id);
+      }
+    } catch (error) {
+      console.error(error);
+      onToast({ type: 'error', content: 'Failed to load connections' });
+    }
+  }, [onToast, selectedConnectionId]);
+
+  const loadStats = useCallback(async (connectionId: number) => {
+    setLoading(true);
+    try {
+      const response = await fetchMatchStatistics(connectionId);
+      setStats(response);
+    } catch (error) {
+      console.error(error);
+      onToast({ type: 'error', content: 'Unable to compute match statistics' });
+    } finally {
+      setLoading(false);
+    }
+  }, [onToast]);
+
+  useEffect(() => {
+    void loadConnections();
+  }, [loadConnections]);
+
+  useEffect(() => {
+    if (selectedConnectionId) {
+      void loadStats(selectedConnectionId);
+    } else {
+      setStats([]);
+    }
+  }, [selectedConnectionId, loadStats]);
+
+  const overallRate = useMemo(() => {
+    const totals = stats.reduce(
+      (acc, item) => {
+        acc.total += item.total_values;
+        acc.matched += item.matched_values;
+        return acc;
+      },
+      { total: 0, matched: 0 },
+    );
+    if (!totals.total) return 0;
+    return totals.matched / totals.total;
+  }, [stats]);
+
+  return (
+    <Stack spacing={4} component="section">
+      <Paper variant="outlined" sx={{ p: { xs: 3, md: 4 } }}>
+        <Stack spacing={2}>
+          <Box sx={{ display: 'flex', flexDirection: { xs: 'column', md: 'row' }, gap: 2 }}>
+            <Box sx={{ flexGrow: 1 }}>
+              <Typography variant="h6" fontWeight={600} gutterBottom>
+                Match insights
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                Monitor the alignment between raw source values and canonical records. Use these insights to prioritise review efforts.
+              </Typography>
+            </Box>
+            <FormControl size="small" sx={{ minWidth: 220 }}>
+              <InputLabel id="match-connection-label">Connection</InputLabel>
+              <Select
+                labelId="match-connection-label"
+                label="Connection"
+                value={selectedConnectionId}
+                onChange={(event) => setSelectedConnectionId(Number(event.target.value))}
+              >
+                {connections.map((connection) => (
+                  <MenuItem key={connection.id} value={connection.id}>
+                    {connection.name}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          </Box>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+            <InsightsRoundedIcon color="primary" />
+            <Box>
+              <Typography variant="subtitle1" fontWeight={600}>
+                Overall match rate
+              </Typography>
+              <Typography variant="h4" fontWeight={700}>
+                {(overallRate * 100).toFixed(1)}%
+              </Typography>
+            </Box>
+          </Box>
+          {loading && <LinearProgress />}
+        </Stack>
+      </Paper>
+
+      {stats.map((item) => (
+        <Paper key={item.mapping_id} variant="outlined" sx={{ p: { xs: 3, md: 4 } }}>
+          <Stack spacing={2}>
+            <Box sx={{ display: 'flex', justifyContent: 'space-between', flexWrap: 'wrap', gap: 2 }}>
+              <Box>
+                <Typography variant="subtitle1" fontWeight={600}>
+                  {item.source_table}.{item.source_field}
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  Dimension: {item.ref_dimension}
+                </Typography>
+              </Box>
+              <Box textAlign="right">
+                <Typography variant="h5" fontWeight={700}>
+                  {(item.match_rate * 100).toFixed(1)}%
+                </Typography>
+                <Typography variant="caption" color="text.secondary">
+                  {item.matched_values} / {item.total_values} matched
+                </Typography>
+              </Box>
+            </Box>
+
+            <Box>
+              <Typography variant="subtitle2" fontWeight={600} gutterBottom>
+                Top unmatched values
+              </Typography>
+              <Stack spacing={1}>
+                {item.top_unmatched.length ? (
+                  item.top_unmatched.map((unmatched) => (
+                    <Paper key={unmatched.raw_value} variant="outlined" sx={{ p: 2 }}>
+                      <Typography variant="body2" fontWeight={600}>
+                        {unmatched.raw_value}
+                      </Typography>
+                      <Typography variant="caption" color="text.secondary">
+                        {unmatched.occurrence_count} occurrences
+                      </Typography>
+                      <Box sx={{ mt: 1 }}>{renderSuggestions(unmatched.suggestions)}</Box>
+                    </Paper>
+                  ))
+                ) : (
+                  <Typography variant="body2" color="text.secondary">
+                    Every sampled value met the configured threshold.
+                  </Typography>
+                )}
+              </Stack>
+            </Box>
+          </Stack>
+        </Paper>
+      ))}
+
+      {!stats.length && !loading && (
+        <Paper variant="outlined" sx={{ p: 3 }}>
+          <Typography variant="body2" color="text.secondary">
+            No mappings available for the selected connection yet.
+          </Typography>
+        </Paper>
+      )}
+    </Stack>
+  );
+};
+
+export default MatchInsightsPage;

--- a/reviewer-ui/src/pages/SuggestionsPage.tsx
+++ b/reviewer-ui/src/pages/SuggestionsPage.tsx
@@ -1,0 +1,233 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import DoneRoundedIcon from '@mui/icons-material/DoneRounded';
+import LinkRoundedIcon from '@mui/icons-material/LinkRounded';
+import {
+  Box,
+  Button,
+  Chip,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Paper,
+  Select,
+  Stack,
+  Typography,
+} from '@mui/material';
+
+import {
+  createValueMapping,
+  fetchSourceConnections,
+  fetchUnmatchedValues,
+} from '../api';
+import { useAppState } from '../state/AppStateContext';
+import type {
+  CanonicalValue,
+  SourceConnection,
+  ToastMessage,
+  UnmatchedValueRecord,
+} from '../types';
+
+interface SuggestionsPageProps {
+  onToast: (toast: ToastMessage) => void;
+}
+
+const SuggestionsPage = ({ onToast }: SuggestionsPageProps) => {
+  const { canonicalValues } = useAppState();
+  const [connections, setConnections] = useState<SourceConnection[]>([]);
+  const [selectedConnectionId, setSelectedConnectionId] = useState<number | ''>('');
+  const [unmatched, setUnmatched] = useState<UnmatchedValueRecord[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [manualSelection, setManualSelection] = useState<Record<string, number>>({});
+
+  const canonicalByDimension = useMemo(() => {
+    const map = new Map<string, CanonicalValue[]>();
+    canonicalValues.forEach((value) => {
+      const list = map.get(value.dimension) ?? [];
+      list.push(value);
+      map.set(value.dimension, list);
+    });
+    map.forEach((list, key) => list.sort((a, b) => a.canonical_label.localeCompare(b.canonical_label)));
+    return map;
+  }, [canonicalValues]);
+
+  const loadConnections = useCallback(async () => {
+    try {
+      const records = await fetchSourceConnections();
+      setConnections(records);
+      if (!selectedConnectionId && records.length) {
+        setSelectedConnectionId(records[0].id);
+      }
+    } catch (error) {
+      console.error(error);
+      onToast({ type: 'error', content: 'Failed to load connections' });
+    }
+  }, [onToast, selectedConnectionId]);
+
+  const loadUnmatched = useCallback(async (connectionId: number) => {
+    setLoading(true);
+    try {
+      const records = await fetchUnmatchedValues(connectionId);
+      setUnmatched(records);
+    } catch (error) {
+      console.error(error);
+      onToast({ type: 'error', content: 'Unable to load unmatched values' });
+    } finally {
+      setLoading(false);
+    }
+  }, [onToast]);
+
+  useEffect(() => {
+    void loadConnections();
+  }, [loadConnections]);
+
+  useEffect(() => {
+    if (selectedConnectionId) {
+      void loadUnmatched(selectedConnectionId);
+    } else {
+      setUnmatched([]);
+    }
+  }, [selectedConnectionId, loadUnmatched]);
+
+  const applyMapping = async (
+    record: UnmatchedValueRecord,
+    canonicalId: number,
+    confidence?: number,
+    suggestedLabel?: string,
+  ) => {
+    if (!selectedConnectionId) return;
+    try {
+      await createValueMapping(selectedConnectionId, {
+        source_table: record.source_table,
+        source_field: record.source_field,
+        raw_value: record.raw_value,
+        canonical_id: canonicalId,
+        status: 'approved',
+        confidence,
+        suggested_label: suggestedLabel,
+      });
+      setUnmatched((prev) => prev.filter((item) => item !== record));
+      onToast({ type: 'success', content: `Mapped ${record.raw_value}` });
+    } catch (error) {
+      console.error(error);
+      onToast({ type: 'error', content: 'Failed to store mapping' });
+    }
+  };
+
+  const handleManualApply = async (record: UnmatchedValueRecord) => {
+    const key = `${record.mapping_id}:${record.raw_value}`;
+    const canonicalId = manualSelection[key];
+    if (!canonicalId) {
+      onToast({ type: 'error', content: 'Select a canonical value first.' });
+      return;
+    }
+    await applyMapping(record, canonicalId);
+  };
+
+  return (
+    <Stack spacing={4} component="section">
+      <Paper variant="outlined" sx={{ p: { xs: 3, md: 4 } }}>
+        <Stack spacing={2}>
+          <Box sx={{ display: 'flex', flexDirection: { xs: 'column', md: 'row' }, gap: 2 }}>
+            <Box sx={{ flexGrow: 1 }}>
+              <Typography variant="h6" fontWeight={600} gutterBottom>
+                Triage unmatched values
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                Review low-confidence matches and confirm the appropriate canonical record. Suggestions are ranked using the semantic matcher.
+              </Typography>
+            </Box>
+            <FormControl size="small" sx={{ minWidth: 220 }}>
+              <InputLabel id="suggestions-connection-label">Connection</InputLabel>
+              <Select
+                labelId="suggestions-connection-label"
+                label="Connection"
+                value={selectedConnectionId}
+                onChange={(event) => setSelectedConnectionId(Number(event.target.value))}
+              >
+                {connections.map((connection) => (
+                  <MenuItem key={connection.id} value={connection.id}>
+                    {connection.name}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          </Box>
+          {loading && <Typography variant="body2">Loading unmatched values…</Typography>}
+        </Stack>
+      </Paper>
+
+      {unmatched.map((record) => {
+        const key = `${record.mapping_id}:${record.raw_value}`;
+        const canonicalOptions = canonicalByDimension.get(record.ref_dimension) ?? [];
+        return (
+          <Paper key={key} variant="outlined" sx={{ p: { xs: 3, md: 4 } }}>
+            <Stack spacing={2}>
+              <Box sx={{ display: 'flex', justifyContent: 'space-between', flexWrap: 'wrap', gap: 2 }}>
+                <Box>
+                  <Typography variant="subtitle1" fontWeight={600}>
+                    {record.raw_value}
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    {record.source_table}.{record.source_field} · {record.ref_dimension}
+                  </Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    {record.occurrence_count} occurrences
+                  </Typography>
+                </Box>
+                <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap" useFlexGap>
+                  {record.suggestions.map((suggestion) => (
+                    <Chip
+                      key={suggestion.canonical_id}
+                      label={`${suggestion.canonical_label} (${(suggestion.score * 100).toFixed(0)}%)`}
+                      onClick={() => void applyMapping(record, suggestion.canonical_id, suggestion.score, suggestion.canonical_label)}
+                      icon={<DoneRoundedIcon />}
+                      variant="outlined"
+                    />
+                  ))}
+                </Stack>
+              </Box>
+
+              <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} alignItems={{ xs: 'stretch', md: 'center' }}>
+                <FormControl sx={{ minWidth: 220 }}>
+                  <InputLabel id={`manual-select-${key}`}>Select canonical</InputLabel>
+                  <Select
+                    labelId={`manual-select-${key}`}
+                    label="Select canonical"
+                    value={manualSelection[key] ?? ''}
+                    onChange={(event) =>
+                      setManualSelection((prev) => ({ ...prev, [key]: Number(event.target.value) }))
+                    }
+                  >
+                    {canonicalOptions.map((option) => (
+                      <MenuItem key={option.id} value={option.id}>
+                        {option.canonical_label}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+                <Button
+                  variant="contained"
+                  startIcon={<LinkRoundedIcon />}
+                  onClick={() => void handleManualApply(record)}
+                  disabled={!manualSelection[key]}
+                >
+                  Link to canonical
+                </Button>
+              </Stack>
+            </Stack>
+          </Paper>
+        );
+      })}
+
+      {!unmatched.length && !loading && (
+        <Paper variant="outlined" sx={{ p: 3 }}>
+          <Typography variant="body2" color="text.secondary">
+            All sampled values are currently mapped. Great work!
+          </Typography>
+        </Paper>
+      )}
+    </Stack>
+  );
+};
+
+export default SuggestionsPage;

--- a/reviewer-ui/src/state/AppStateContext.tsx
+++ b/reviewer-ui/src/state/AppStateContext.tsx
@@ -1,0 +1,112 @@
+import {
+  createContext,
+  PropsWithChildren,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+
+import {
+  fetchCanonicalValues,
+  fetchConfig,
+} from '../api';
+import type { CanonicalValue, SystemConfig } from '../types';
+
+interface AppStateValue {
+  config: SystemConfig | null;
+  canonicalValues: CanonicalValue[];
+  isLoading: boolean;
+  loadError: string | null;
+  refresh: () => Promise<boolean>;
+  setConfig: (updater: SystemConfig | null | ((prev: SystemConfig | null) => SystemConfig | null)) => void;
+  updateCanonicalValues: (
+    updater: CanonicalValue[] | ((prev: CanonicalValue[]) => CanonicalValue[]),
+  ) => void;
+}
+
+const AppStateContext = createContext<AppStateValue | undefined>(undefined);
+
+function sortCanonical(values: CanonicalValue[]): CanonicalValue[] {
+  return [...values].sort((a, b) => a.canonical_label.localeCompare(b.canonical_label));
+}
+
+export const AppStateProvider = ({ children }: PropsWithChildren) => {
+  const [config, setConfig] = useState<SystemConfig | null>(null);
+  const [canonicalValues, setCanonicalValues] = useState<CanonicalValue[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  const refresh = useCallback(async (): Promise<boolean> => {
+    setIsLoading(true);
+    setLoadError(null);
+    const [configResult, canonicalResult] = await Promise.allSettled([
+      fetchConfig(),
+      fetchCanonicalValues(),
+    ]);
+
+    const errors: string[] = [];
+
+    if (configResult.status === 'fulfilled') {
+      setConfig(configResult.value);
+    } else {
+      console.error('Failed to load configuration', configResult.reason);
+      errors.push('configuration');
+    }
+
+    if (canonicalResult.status === 'fulfilled') {
+      setCanonicalValues(sortCanonical(canonicalResult.value));
+    } else {
+      console.error('Failed to load canonical values', canonicalResult.reason);
+      errors.push('canonical library');
+    }
+
+    setIsLoading(false);
+
+    if (errors.length) {
+      const message = `Unable to load ${errors.join(' & ')}`;
+      setLoadError(message);
+      return false;
+    }
+
+    return true;
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const value = useMemo<AppStateValue>(
+    () => ({
+      config,
+      canonicalValues,
+      isLoading,
+      loadError,
+      refresh,
+      setConfig: (updater) => {
+        setConfig((prev) =>
+          typeof updater === 'function' ? (updater as (val: SystemConfig | null) => SystemConfig | null)(prev) : updater,
+        );
+      },
+      updateCanonicalValues: (updater) => {
+        setCanonicalValues((prev) => {
+          const next =
+            typeof updater === 'function' ? (updater as (values: CanonicalValue[]) => CanonicalValue[])(prev) : updater;
+          return sortCanonical(next);
+        });
+      },
+    }),
+    [canonicalValues, config, isLoading, loadError, refresh],
+  );
+
+  return <AppStateContext.Provider value={value}>{children}</AppStateContext.Provider>;
+};
+
+export function useAppState(): AppStateValue {
+  const context = useContext(AppStateContext);
+  if (!context) {
+    throw new Error('useAppState must be used within an AppStateProvider');
+  }
+  return context;
+}

--- a/reviewer-ui/src/types.ts
+++ b/reviewer-ui/src/types.ts
@@ -5,6 +5,12 @@ export interface CanonicalValue {
   description?: string | null;
 }
 
+export interface CanonicalValueUpdatePayload {
+  dimension?: string;
+  canonical_label?: string;
+  description?: string | null;
+}
+
 export interface MatchCandidate {
   canonical_id: number;
   canonical_label: string;
@@ -40,3 +46,127 @@ export interface SystemConfigUpdate {
   top_k?: number;
   llm_api_key?: string;
 }
+
+export interface ToastMessage {
+  type: 'success' | 'error';
+  content: string;
+}
+
+export interface SourceConnection {
+  id: number;
+  name: string;
+  db_type: string;
+  host: string;
+  port: number;
+  database: string;
+  username: string;
+  options?: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface SourceConnectionCreatePayload {
+  name: string;
+  db_type: string;
+  host: string;
+  port: number;
+  database: string;
+  username: string;
+  password?: string;
+  options?: string | null;
+}
+
+export interface SourceConnectionUpdatePayload extends Partial<SourceConnectionCreatePayload> {}
+
+export interface SourceFieldMapping {
+  id: number;
+  source_connection_id: number;
+  source_table: string;
+  source_field: string;
+  ref_dimension: string;
+  description?: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface SourceFieldMappingPayload {
+  source_table: string;
+  source_field: string;
+  ref_dimension: string;
+  description?: string | null;
+}
+
+export interface SourceSampleValuePayload {
+  raw_value: string;
+  occurrence_count: number;
+  dimension?: string | null;
+}
+
+export interface SourceSample {
+  id: number;
+  source_connection_id: number;
+  source_table: string;
+  source_field: string;
+  dimension?: string | null;
+  raw_value: string;
+  occurrence_count: number;
+  last_seen_at: string;
+}
+
+export interface FieldMatchStats {
+  mapping_id: number;
+  source_table: string;
+  source_field: string;
+  ref_dimension: string;
+  total_values: number;
+  matched_values: number;
+  unmatched_values: number;
+  match_rate: number;
+  top_unmatched: UnmatchedValuePreview[];
+}
+
+export interface UnmatchedValuePreview {
+  raw_value: string;
+  occurrence_count: number;
+  suggestions: MatchCandidate[];
+}
+
+export interface UnmatchedValueRecord extends UnmatchedValuePreview {
+  mapping_id: number;
+  source_table: string;
+  source_field: string;
+  ref_dimension: string;
+}
+
+export interface ValueMapping {
+  id: number;
+  source_connection_id: number;
+  source_table: string;
+  source_field: string;
+  raw_value: string;
+  canonical_id: number;
+  status: string;
+  confidence?: number | null;
+  suggested_label?: string | null;
+  notes?: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ValueMappingExpanded extends ValueMapping {
+  canonical_label: string;
+  ref_dimension: string;
+}
+
+export interface ValueMappingPayload {
+  source_table: string;
+  source_field: string;
+  raw_value: string;
+  canonical_id: number;
+  status?: string;
+  confidence?: number | null;
+  suggested_label?: string | null;
+  notes?: string | null;
+}
+
+export interface ValueMappingUpdatePayload extends Partial<ValueMappingPayload> {}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -22,7 +22,7 @@ from api.app.database import create_db_engine, init_db, get_session
 
 
 def build_test_client() -> TestClient:
-    settings = Settings(database_url="sqlite:///:memory:", match_threshold=0.0)
+    settings = Settings(database_url="sqlite:///:memory:", match_threshold=0.55)
     app = create_app(settings)
     engine = create_db_engine(settings)
     app.state.engine = engine
@@ -54,3 +54,118 @@ def test_match_proposal_returns_candidates() -> None:
     assert payload["matches"]
     top_match = payload["matches"][0]
     assert top_match["canonical_label"] in {"Married", "Single"}
+
+
+def test_canonical_crud_operations() -> None:
+    client = build_test_client()
+
+    create_response = client.post(
+        "/api/reference/canonical",
+        json={"dimension": "test", "canonical_label": "Alpha", "description": "seed"},
+    )
+    assert create_response.status_code == 201
+    created = create_response.json()
+    canonical_id = created["id"]
+
+    update_response = client.put(
+        f"/api/reference/canonical/{canonical_id}",
+        json={"canonical_label": "Alpha Prime"},
+    )
+    assert update_response.status_code == 200
+    assert update_response.json()["canonical_label"] == "Alpha Prime"
+
+    delete_response = client.delete(f"/api/reference/canonical/{canonical_id}")
+    assert delete_response.status_code == 204
+
+
+def test_source_mapping_flow() -> None:
+    client = build_test_client()
+
+    # Create a source connection
+    connection_response = client.post(
+        "/api/source/connections",
+        json={
+            "name": "crm",
+            "db_type": "postgres",
+            "host": "localhost",
+            "port": 5432,
+            "database": "crm",
+            "username": "svc",
+        },
+    )
+    assert connection_response.status_code == 201
+    connection_id = connection_response.json()["id"]
+
+    # Map a field to the marital_status dimension
+    mapping_response = client.post(
+        f"/api/source/connections/{connection_id}/mappings",
+        json={
+            "source_table": "customers",
+            "source_field": "marital",
+            "ref_dimension": "marital_status",
+        },
+    )
+    assert mapping_response.status_code == 201
+    mapping_id = mapping_response.json()["id"]
+
+    # Ingest raw values (one typo, one exact match)
+    ingest_response = client.post(
+        f"/api/source/connections/{connection_id}/samples",
+        json={
+            "source_table": "customers",
+            "source_field": "marital",
+            "values": [
+                {"raw_value": "Singel", "occurrence_count": 3, "dimension": "marital_status"},
+                {"raw_value": "Married", "occurrence_count": 5, "dimension": "marital_status"},
+            ],
+        },
+    )
+    assert ingest_response.status_code == 201
+
+    # Compute match statistics
+    stats_response = client.get(f"/api/source/connections/{connection_id}/match-stats")
+    assert stats_response.status_code == 200
+    stats = stats_response.json()
+    assert stats
+    stat = next(item for item in stats if item["mapping_id"] == mapping_id)
+    assert stat["unmatched_values"] >= 1
+    assert stat["total_values"] == 8
+
+    # Retrieve unmatched values (should include "Singel")
+    unmatched_response = client.get(f"/api/source/connections/{connection_id}/unmatched")
+    assert unmatched_response.status_code == 200
+    unmatched = unmatched_response.json()
+    assert any(record["raw_value"] == "Singel" for record in unmatched)
+
+    # Approve a mapping for the typo using the existing canonical "Single"
+    canonical_response = client.get("/api/reference/canonical")
+    canonical_options = canonical_response.json()
+    single = next(item for item in canonical_options if item["canonical_label"] == "Single")
+
+    create_mapping_response = client.post(
+        f"/api/source/connections/{connection_id}/value-mappings",
+        json={
+            "source_table": "customers",
+            "source_field": "marital",
+            "raw_value": "Singel",
+            "canonical_id": single["id"],
+            "status": "approved",
+        },
+    )
+    assert create_mapping_response.status_code == 201
+
+    # The value should disappear from unmatched results
+    unmatched_after = client.get(f"/api/source/connections/{connection_id}/unmatched").json()
+    assert not any(record["raw_value"] == "Singel" for record in unmatched_after)
+
+    # Connection specific mapping list
+    connection_mappings = client.get(
+        f"/api/source/connections/{connection_id}/value-mappings"
+    )
+    assert connection_mappings.status_code == 200
+    assert connection_mappings.json()
+
+    # Global mapping list
+    all_mappings = client.get("/api/source/value-mappings")
+    assert all_mappings.status_code == 200
+    assert all_mappings.json()


### PR DESCRIPTION
## Summary
- add SQLModel tables, schemas, and FastAPI routes to manage source connections, mappings, samples, and value mappings
- restructure the React reviewer UI into a routed, multi-page experience with global state management and new data stewardship screens
- document the new workflows and extend API/React helpers and tests to cover end-to-end source harmonisation scenarios

## Testing
- pytest
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dbad269fec8332bfd085c345c5f0e5