### PR TITLE
Fix Reviewer UI deep link routing with Nginx SPA fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ This command starts:
 
 - **PostgreSQL** (`db`) seeded with example canonical values and configuration defaults.
 - **FastAPI backend** (`api`) exposing REST endpoints under `http://localhost:8000`.
-- **Reviewer UI** (`reviewer-ui`) served from `http://localhost:5173` with a Material UI design system and multi-theme support.
+- **Reviewer UI** (`reviewer-ui`) served from `http://localhost:5173` with a Material UI design system and multi-theme support. The
+  container now ships a custom Nginx configuration that falls back to `index.html`, so deep links such as
+  `http://localhost:5173/dashboard` or browser refreshes on nested routes resolve correctly without returning a 404.
 
 The first boot performs all schema creation and seeding automatically. All runtime changes (matching thresholds, preferred matcher backend, API keys, additional canonical values, etc.) should be made through the Reviewer UI. No extra scripts are required after `docker compose up`.
 
@@ -58,6 +60,18 @@ Endpoints accept and return structured JSON payloads that align with the React T
 ```
 
 The repository now contains a fully functional end-to-end workflow with integration tests in `tests/`, a semantic matcher in `matcher/`, a FastAPI backend in `api/`, and a multi-page React dashboard in `reviewer-ui/` with accessible theme switching baked into the header.
+
+## Testing
+
+Run the Python unit and integration test suite with:
+
+```bash
+pytest
+```
+
+The new Reviewer UI deployment checks verify that the custom Nginx configuration is copied into the container image and that it
+rewrites unknown application routes back to `index.html`. This prevents regressions where client-side routes return HTTP 404s
+after a page refresh.
 
 ## Feature Breakdown
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -36,3 +36,8 @@
 - Provide a self-service reviewer dashboard with analytics (e.g., top inconsistent values).
 - Align with external ontologies and standards (e.g., ISO country codes, education classifications).
 - Integrate with data catalogs such as DataHub to surface lineage and metadata.
+
+## 8. Operational Hardening
+- Serve the Reviewer UI with an SPA-aware Nginx configuration so direct navigation to deep links (e.g., `/dashboard`) and
+  browser refreshes resolve without 404 responses.
+- Cache static assets aggressively while still surfacing errors for missing bundles, aiding troubleshooting during upgrades.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    integration: marks tests that perform cross-component integration checks.

--- a/reviewer-ui/Dockerfile
+++ b/reviewer-ui/Dockerfile
@@ -14,5 +14,6 @@ RUN npm run build
 
 FROM nginx:1.25-alpine
 COPY --from=build /app/dist /usr/share/nginx/html
+COPY nginx/default.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/reviewer-ui/nginx/default.conf
+++ b/reviewer-ui/nginx/default.conf
@@ -1,0 +1,18 @@
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Serve static assets directly and fail fast if the file is missing.
+    location /assets/ {
+        try_files $uri =404;
+        add_header Cache-Control "public, max-age=31536000, immutable";
+    }
+
+    # Let the React router handle application routes by falling back to index.html.
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/tests/test_reviewer_ui_deployment.py
+++ b/tests/test_reviewer_ui_deployment.py
@@ -1,0 +1,27 @@
+"""Tests for Reviewer UI deployment artefacts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+NGINX_CONF = REPO_ROOT / "reviewer-ui" / "nginx" / "default.conf"
+DOCKERFILE = REPO_ROOT / "reviewer-ui" / "Dockerfile"
+
+
+def test_nginx_config_has_history_fallback() -> None:
+    """Ensure Nginx rewrites unknown routes to index.html for the SPA."""
+
+    config_text = NGINX_CONF.read_text(encoding="utf-8")
+    assert "try_files $uri $uri/ /index.html;" in config_text
+    assert "location / {" in config_text
+
+
+@pytest.mark.integration
+def test_dockerfile_copies_custom_nginx_config() -> None:
+    """The Dockerfile should ship the custom Nginx config into the runtime image."""
+
+    dockerfile_text = DOCKERFILE.read_text(encoding="utf-8")
+    assert "COPY nginx/default.conf /etc/nginx/conf.d/default.conf" in dockerfile_text


### PR DESCRIPTION
## Summary
- add a custom Nginx configuration with SPA history fallback for the Reviewer UI image
- ensure the Dockerfile copies the configuration and document the behavior in README and feature docs
- add pytest coverage for the deployment artefacts and register the integration test marker

## Testing
- pytest
- npm run build (from reviewer-ui)


------
https://chatgpt.com/codex/tasks/task_e_68dbcd3d26c48332bf2637514637fc62