### PR TITLE
refactor(ui): adopt bootstrap and expand canonical governance

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This command starts:
 
 - **PostgreSQL** (`db`) seeded with example canonical values and configuration defaults.
 - **FastAPI backend** (`api`) exposing REST endpoints under `http://localhost:8000`.
-- **Reviewer UI** (`reviewer-ui`) served from `http://localhost:5173` with a Material UI design system and multi-theme support. The
+- **Reviewer UI** (`reviewer-ui`) served from `http://localhost:5173` with a Bootstrap 5 design system and multi-theme support. The
   container now ships a custom Nginx configuration that falls back to `index.html`, so deep links such as
   `http://localhost:5173/dashboard` or browser refreshes on nested routes resolve correctly without returning a 404.
 
@@ -24,12 +24,16 @@ The first boot performs all schema creation and seeding automatically. All runti
 
 The interface is organised into task-focused pages that surface the entire curation workflow:
 
-- **Dashboard** – configure matcher parameters, experiment with semantic suggestions, and curate canonical values with inline editing.
+- **Dashboard** – configure matcher parameters and experiment with semantic suggestions in a live playground.
+- **Canonical Library** – manage curated reference values, filter by dimension, import tabular data in bulk, and export the library to CSV.
 - **Source Connections** – register and maintain connectivity metadata for upstream systems.
 - **Field Mappings** – align source tables/fields to reference dimensions and ingest sample values for reconciliation analytics.
 - **Match Insights** – visualise match rates per mapping, inspect top outliers, and track overall harmonisation health.
 - **Suggestions** – approve semantic suggestions or manually link raw values to canonical standards.
 - **Mapping History** – audit every approved mapping, edit or retire entries, and export a normalised view per connection.
+
+Detailed curation guidance, including an import-ready Abu Dhabi region dataset for the canonical library, lives in
+[`docs/CANONICAL_LIBRARY.md`](docs/CANONICAL_LIBRARY.md).
 
 ### API highlights
 

--- a/docs/CANONICAL_LIBRARY.md
+++ b/docs/CANONICAL_LIBRARY.md
@@ -1,0 +1,69 @@
+# Canonical Library Guide
+
+The canonical library centralises every approved reference value. Reviewers can curate records manually or load large batches of
+rows in one action. This guide documents the workflows now supported by the dedicated **Canonical Library** page in the reviewer
+UI and provides an Abu Dhabi–specific dataset ready for import.
+
+## Page overview
+
+The library page offers four key capabilities:
+
+1. **Filter & search** – Narrow the table by dimension and/or keyword to locate existing canonical values quickly.
+2. **Create & edit** – Launch the editor modal to add brand-new entries or update labels, dimensions, and descriptions.
+3. **Bulk import** – Paste a tab- or comma-delimited payload to create many canonical rows at once.
+4. **Export** – Download the filtered table to CSV for auditing or offline collaboration.
+
+All changes are persisted via the `/api/reference/canonical` endpoints exposed by the FastAPI backend.
+
+## Adding or editing records
+
+1. Open **Canonical Library** from the navigation bar.
+2. Use the **New canonical value** button to capture the dimension, canonical label, and optional description (e.g., Arabic
+   translation or code).
+3. To edit a row, choose **Edit** in the table. Adjust any field and save to persist the change.
+4. Use **Delete** to remove records that are no longer valid. A confirmation modal protects against accidental deletions.
+
+## Bulk import walkthrough
+
+The importer expects rows in the following structure:
+
+```
+dimension\tcanonical label\t(optional description columns)
+```
+
+* Columns can be separated by tabs, commas, or 2+ spaces. Additional columns are concatenated into the description.
+* Empty dimension cells inherit the "Default dimension" value provided in the modal (useful when pasting single-dimension data).
+
+### Abu Dhabi regional dataset
+
+A ready-to-use dataset that mirrors the source material provided with this task lives at
+[`docs/data/abu_dhabi_canonical.tsv`](data/abu_dhabi_canonical.tsv). It contains the emirate, region, and district hierarchy with
+English labels, numeric codes, and Arabic names in the description.
+
+To bulk load the dataset:
+
+1. Open `docs/data/abu_dhabi_canonical.tsv` in your editor or run:
+   ```bash
+   cat docs/data/abu_dhabi_canonical.tsv
+   ```
+2. Copy all rows starting from the second line (skip the header row).
+3. In the Reviewer UI, select **Bulk import** → paste the copied rows → click **Import rows**.
+4. The importer reports how many records were created and automatically sorts them alongside existing values.
+
+### Tips for custom datasets
+
+- Include stable identifiers (codes) in the description field so downstream consumers can map raw values reliably.
+- Use consistent dimensions (e.g., `region`, `district`, `currency`) to keep filtering predictable.
+- When storing multilingual labels, concatenate translations with clear separators, for example: `English | Arabic`.
+- The importer ignores blank lines and lines prefixed with `#`, enabling lightweight in-line commentary.
+
+## Troubleshooting
+
+- **"Unable to load canonical library" toast** – Verify the backend container is running. The UI now reports which resources
+  failed to load.
+- **Import validation errors** – Ensure each row contains at least two columns (dimension + canonical label). Codes and
+  descriptions may be optional but are strongly recommended.
+- **Duplicate records** – The API allows duplicates; run the export to CSV and deduplicate externally if necessary.
+
+With these enhancements the canonical library is resilient enough to manage the full Abu Dhabi reference taxonomy and any future
+expansions.

--- a/docs/data/abu_dhabi_canonical.tsv
+++ b/docs/data/abu_dhabi_canonical.tsv
@@ -1,0 +1,226 @@
+dimension	canonical_label	description
+region	Abu Dhabi Emirate	Code: 01 | Arabic: إمارة أبوظبي
+region	Abu Dhabi Region	Code: 0101 | Arabic: منطقة أبوظبي
+region	Al Ain Region	Code: 0102 | Arabic: منطقة العين
+region	Al Dhafra Region	Code: 0103 | Arabic: منطقة الظفرة
+district	Abu Dhabi Emirate	Code: 01 | Arabic: إمارة أبوظبي
+district	Abu Dhabi Region	Code: 0101 | Arabic: منطقة أبوظبي
+district	Al Danah	Code: 01010010 | Arabic: الدانة
+district	Al Manhal	Code: 01010020 | Arabic: المنهل
+district	Al Hisn	Code: 01010030 | Arabic: الحصن
+district	Al Zahiyah	Code: 01010040 | Arabic: الزاهية
+district	Al Nahyan	Code: 01010050 | Arabic: آل نهيان
+district	Al Lulu Island	Code: 01010060 | Arabic: جزيرة اللولو
+district	Qasr Al Bahr	Code: 01010070 | Arabic: قصر البحر
+district	Zayed Port	Code: 01010080 | Arabic: ميناء زايد
+district	Al Maryah Island	Code: 01010090 | Arabic: جزيرة المارية
+district	Al Reem Island	Code: 01010100 | Arabic: جزيرة الريم
+district	Al Khalidiyah	Code: 01010110 | Arabic: الخالدية
+district	Al Bateen	Code: 01010120 | Arabic: البطين
+district	Al Mushrif	Code: 01010130 | Arabic: المشرف
+district	Al Kasir	Code: 01010140 | Arabic: الكاسر
+district	Abu Dhabi Islands	Code: 01010150 | Arabic: جزر أبوظبي
+district	Hadbat Al Za'faranah	Code: 01010160 | Arabic: حدبة الزعفرانة
+district	Al Kheeran	Code: 01010170 | Arabic: الخيران
+district	Al Ras Al Akhdar	Code: 01010180 | Arabic: الرأس الأخضر
+district	Al Hidayriyyat	Code: 01010190 | Arabic: الحديريات
+district	Al Saadiyat Island	Code: 01010200 | Arabic: جزيرة السعديات
+district	Al Qurm	Code: 01010210 | Arabic: القرم
+district	Al Reem East Island	Code: 01010220 | Arabic: جزيرة الريم شرق
+district	Um Yifeenah Island	Code: 01010230 | Arabic: جزيرة أم يفينة
+district	Qirqishan	Code: 01010240 | Arabic: قرقشان
+district	Al Sa'adah	Code: 01010250 | Arabic: السعادة
+district	Al Rawdah	Code: 01010260 | Arabic: الروضة
+district	Al Muzoun	Code: 01010270 | Arabic: المزون
+district	Al Fteysi Island	Code: 01010280 | Arabic: جزيرة الفطيسي
+district	Al Muntazah	Code: 01010290 | Arabic: المنتزه
+district	Al Jubail Island	Code: 01010300 | Arabic: جزيرة الجبيل
+district	Bilrimaid Island	Code: 01010310 | Arabic: جزيرة بالرميد
+district	Sas Al Nakhl	Code: 01010320 | Arabic: ساس النخل
+district	Al Sammaliyyah Island	Code: 01010330 | Arabic: جزيرة السمالية
+district	Al Halah Island	Code: 01010340 | Arabic: جزيرة الحالة
+district	Rabdan	Code: 01010350 | Arabic: ربدان
+district	Musaffah	Code: 01010360 | Arabic: مصفح
+district	Ramhan Island	Code: 01010370 | Arabic: جزيرة رمحان
+district	Bilghaylam Island	Code: 01010380 | Arabic: جزيرة بلغيلم
+district	Bu Niyaydah	Code: 01010390 | Arabic: بو نييدة
+district	Khalifa City	Code: 01010400 | Arabic: مدينة خليفة
+district	Fahid Island	Code: 01010410 | Arabic: جزيرة فاهد
+district	Abu Dhabi Industrial City	Code: 01010420 | Arabic: مدينة أبوظبي الصناعية
+district	Al Rahah	Code: 01010430 | Arabic: الراحة
+district	Nourai Island	Code: 01010440 | Arabic: جزيرة نوراي
+district	Abu Al Habl Island	Code: 01010450 | Arabic: جزيرة أبو الحبل
+district	Al Aliah Island	Code: 01010460 | Arabic: جزيرة العالية
+district	Mohamed Bin Zayed City	Code: 01010470 | Arabic: مدينة محمد بن زايد
+district	Al Mihsinah	Code: 01010480 | Arabic: المحسنة
+district	Al Aryam Island	Code: 01010490 | Arabic: جزيرة الأريام
+district	Zayed City	Code: 01010500 | Arabic: مدينة زايد
+district	Yas Island	Code: 01010510 | Arabic: جزيرة ياس
+district	Al Selmiyyah	Code: 01010520 | Arabic: السلمية
+district	Al Heel Island	Code: 01010530 | Arabic: جزيرة الحيل
+district	Al Bahyah	Code: 01010540 | Arabic: الباهية
+district	Ujaij	Code: 01010550 | Arabic: عجيج
+district	Al Matar	Code: 01010560 | Arabic: المطار
+district	Al Bihouth	Code: 01010570 | Arabic: البحوث
+district	Al Zubarah	Code: 01010580 | Arabic: الزبارة
+district	Al Nouf	Code: 01010590 | Arabic: النوف
+district	Al Reef	Code: 01010600 | Arabic: الريف
+district	Shakhbout City	Code: 01010610 | Arabic: مدينة شخبوط
+district	Jarn Yafour	Code: 01010620 | Arabic: جرن يافور
+district	Al Shahamah	Code: 01010630 | Arabic: الشهامة
+district	Al Shinayin	Code: 01010640 | Arabic: الشناين
+district	Al Sader	Code: 01010650 | Arabic: الصدر
+district	Bani Yas	Code: 01010660 | Arabic: بني ياس
+district	Al Shelaylah Island	Code: 01010670 | Arabic: جزيرة الشليلة
+district	Al Shawamekh	Code: 01010680 | Arabic: الشوامخ
+district	Al Hanyourah	Code: 01010690 | Arabic: الحنيورة
+district	Rawdat Al Reef	Code: 01010700 | Arabic: روضة الريف
+district	Al Falah	Code: 01010710 | Arabic: الفلاح
+district	Al Shamkhah	Code: 01010720 | Arabic: الشامخة
+district	Al Rahbah	Code: 01010730 | Arabic: الرحبة
+district	Abu Mreikhah	Code: 01010740 | Arabic: أبو مريخة
+district	Al Wathbah	Code: 01010750 | Arabic: الوثبة
+district	Al Khidayrah	Code: 01010760 | Arabic: الخضيرة
+district	Madinat Al Riyad	Code: 01010770 | Arabic: مدينة الرياض
+district	Al Nahdah	Code: 01010780 | Arabic: النهضة
+district	Al Samhah	Code: 01010790 | Arabic: السمحة
+district	Al Taweelah	Code: 01010800 | Arabic: الطويلة
+district	Mshayrif	Code: 01010810 | Arabic: مشيرف
+district	Muwaylih	Code: 01010820 | Arabic: مويلح
+district	Zayed Military City	Code: 01010830 | Arabic: مدينة زايد العسكرية
+district	Al Mi'rad	Code: 01010840 | Arabic: المعراض
+district	Al Ma'mourah	Code: 01010850 | Arabic: المعمورة
+district	Al Haffar	Code: 01010860 | Arabic: الحفار
+district	Khalifa Industrial	Code: 01010870 | Arabic: خليفة الصناعية
+district	Ghanadhah	Code: 01010880 | Arabic: غناضة
+district	Al Smeeh	Code: 01010890 | Arabic: السميح
+district	Abu Al Abyad Island	Code: 01010900 | Arabic: جزيرة أبو الأبيض
+district	Al 'Adlah	Code: 01010910 | Arabic: العدلة
+district	Al 'Asheesh	Code: 01010920 | Arabic: العشيش
+district	Al Sout	Code: 01010930 | Arabic: السوت
+district	Al Fayah	Code: 01010940 | Arabic: الفاية
+district	Dhaharat Al Teeb	Code: 01010950 | Arabic: ظهارة الطيب
+district	Ghadeer Al Tayr	Code: 01010960 | Arabic: غدير الطير
+district	Al Layyan	Code: 01010970 | Arabic: الليان
+district	Dihan	Code: 01010980 | Arabic: دهان
+district	Al Khatm	Code: 01010990 | Arabic: الختم
+district	Ghantout	Code: 01011000 | Arabic: غنتوت
+district	Al Ain Region	Code: 0102 | Arabic: منطقة العين
+district	Al Jimi	Code: 01020010 | Arabic: الجيمي
+district	Al Mu'tarid	Code: 01020020 | Arabic: المعترض
+district	Al Qattarah	Code: 01020030 | Arabic: القطارة
+district	Al Mas'oudi	Code: 01020040 | Arabic: المسعودي
+district	Al Muwaij'i	Code: 01020050 | Arabic: المويجعي
+district	Al Tiwayya	Code: 01020060 | Arabic: الطوية
+district	Al Khibeesi	Code: 01020070 | Arabic: الخبيصي
+district	Central District	Code: 01020080 | Arabic: وسط المدينة
+district	Al Nabbagh	Code: 01020090 | Arabic: النباغ
+district	Al Jahili	Code: 01020100 | Arabic: الجاهلي
+district	Hili	Code: 01020110 | Arabic: هيلي
+district	Al Mutaw'ah	Code: 01020120 | Arabic: المطاوعة
+district	Falaj Hazza'	Code: 01020130 | Arabic: فلج هزاع
+district	Industrial Area	Code: 01020140 | Arabic: المنطقة الصناعية
+district	Al Sarouj	Code: 01020150 | Arabic: الصاروج
+district	Al Markhaniyyah	Code: 01020160 | Arabic: المرخانية
+district	Al Dahma	Code: 01020170 | Arabic: الدهماء
+district	'Asharij	Code: 01020180 | Arabic: عشارج
+district	Shiab Al Ashkhar	Code: 01020190 | Arabic: شعاب الأشخر
+district	Al Bateen	Code: 01020200 | Arabic: البطين
+district	Al Ruwaydat	Code: 01020210 | Arabic: الرويضات
+district	Al 'Iqabiyyah	Code: 01020220 | Arabic: العقابية
+district	Al Ain International Airport	Code: 01020230 | Arabic: مطار العين الدولي
+district	Bad' Bint Sa'oud	Code: 01020240 | Arabic: بدع بنت سعود
+district	Zakhir	Code: 01020250 | Arabic: زاخر
+district	Al Shuwaymah	Code: 01020260 | Arabic: الشويمة
+district	Al Fou'ah	Code: 01020270 | Arabic: الفوعة
+district	Al Aflaj	Code: 01020280 | Arabic: الأفلاج
+district	Al Maqam	Code: 01020290 | Arabic: المقام
+district	Ghnaymah	Code: 01020300 | Arabic: غنيمة
+district	Al Rawdah Al Sharqiyah	Code: 01020310 | Arabic: الروضة الشرقية
+district	Al Noud	Code: 01020320 | Arabic: النود
+district	Malaqit	Code: 01020330 | Arabic: ملاقط
+district	Mbazzarah Al Khadra	Code: 01020340 | Arabic: مبزرة الخضراء
+district	Ghireebah	Code: 01020350 | Arabic: غريبة
+district	Shi'bat Al Wutah	Code: 01020360 | Arabic: شعبة الوطاه
+district	Al Salamat	Code: 01020370 | Arabic: السلامات
+district	Ni'mah	Code: 01020380 | Arabic: نعمة
+district	Masakin	Code: 01020390 | Arabic: مساكن
+district	Jabal Hafeet	Code: 01020400 | Arabic: جبل حفيت
+district	Al Aamerah	Code: 01020410 | Arabic: العامرة
+district	Ain Al Faydah	Code: 01020420 | Arabic: عين الفايضة
+district	Al Qisees	Code: 01020430 | Arabic: القسيس
+district	Al Dhahir	Code: 01020440 | Arabic: الظاهر
+district	Sweihan	Code: 01020450 | Arabic: سويحان
+district	Khatm Al Shiklah	Code: 01020460 | Arabic: خطم الشكلة
+district	Industrial City	Code: 01020470 | Arabic: المدينة الصناعية
+district	Um Ghafah	Code: 01020480 | Arabic: أم غافة
+district	Nahil	Code: 01020490 | Arabic: ناهل
+district	Al Rawdah	Code: 01020500 | Arabic: الروضة
+district	Al Dhahrah	Code: 01020510 | Arabic: الظاهرة
+district	Sa'	Code: 01020520 | Arabic: صاع
+district	Mazyad	Code: 01020530 | Arabic: مزيد
+district	Al Sad	Code: 01020540 | Arabic: الساد
+district	Al Hiyar	Code: 01020550 | Arabic: الهير
+district	Rimah	Code: 01020560 | Arabic: رماح
+district	Abu Samrah	Code: 01020570 | Arabic: أبو سمرة
+district	Ramlat Sweihan	Code: 01020580 | Arabic: رملة سويحان
+district	Al Faqa'	Code: 01020590 | Arabic: الفقع
+district	Al 'Ajban	Code: 01020600 | Arabic: العجبان
+district	Bu Kirayyah	Code: 01020610 | Arabic: بو كرية
+district	Al Shiwayb	Code: 01020620 | Arabic: الشويب
+district	Al 'Arad	Code: 01020630 | Arabic: العراد
+district	Niqa Al Dheeb	Code: 01020640 | Arabic: نقا الذيب
+district	Al Khaznah	Code: 01020650 | Arabic: الخزنة
+district	Al Wiqan	Code: 01020660 | Arabic: الوقن
+district	Abu Hiraybah	Code: 01020670 | Arabic: أبو حريبة
+district	Al Qou'	Code: 01020680 | Arabic: القوع
+district	Um Al Zumoul	Code: 01020690 | Arabic: أم الزمول
+district	Al Dhafra Region	Code: 0103 | Arabic: منطقة الظفرة
+district	Zayed City	Code: 01030010 | Arabic: مدينة زايد
+district	Al Bday'Ah	Code: 01030020 | Arabic: البْدَيْعَة
+district	Bilji'An	Code: 01030030 | Arabic: بِلْجِعان
+district	Habshan	Code: 01030040 | Arabic: حَبْشَان
+district	Bu Al Dhiyab	Code: 01030050 | Arabic: بو الذياب
+district	Al 'Azeezah	Code: 01030060 | Arabic: العزيزة
+district	Bu Hasa	Code: 01030070 | Arabic: بُو حَصَا
+district	Um Laylah	Code: 01030080 | Arabic: أم ليله
+district	MzeerʻAh	Code: 01030090 | Arabic: مْزِيرْعَة
+district	Tarif	Code: 01030100 | Arabic: طَرِيف
+district	Al Taf Al Gharbi	Code: 01030110 | Arabic: الطف الغربي
+district	Al Zarraf	Code: 01030120 | Arabic: الزَّرَّاف
+district	Western Mahadir	Code: 01030130 | Arabic: المحاضر الغربية
+district	Eastern Mahadir	Code: 01030140 | Arabic: المحاضر الشرقية
+district	Al Rideem	Code: 01030150 | Arabic: الرِّدِيم
+district	Al Marfa	Code: 01030160 | Arabic: المرْفَأ
+district	Al Hadwaniyyah	Code: 01030170 | Arabic: الهدوانية
+district	Al Dhafra Islands	Code: 01030180 | Arabic: جزر منطقة الظفرة
+district	Milaysah	Code: 01030190 | Arabic: مِلَيسَة
+district	Bateen Liwa	Code: 01030200 | Arabic: بَطين ليوا
+district	Yaw Al Nadhrah	Code: 01030210 | Arabic: يَوْ النَّظْرَة
+district	Al Harmiyyah	Code: 01030220 | Arabic: الهَرميَّة
+district	Qirayn Al 'Aysh	Code: 01030230 | Arabic: قِرَيْنْ العَيْش
+district	Khasbat Al Reem	Code: 01030240 | Arabic: خَصبة الرِّيم
+district	Baynounah	Code: 01030250 | Arabic: بينونة
+district	Abu Qrayn	Code: 01030260 | Arabic: أبو قْرَيْن
+district	Mkhayriz	Code: 01030270 | Arabic: مْخَيرِز
+district	Hameem	Code: 01030280 | Arabic: حميم
+district	Al 'Ayif	Code: 01030290 | Arabic: العَايِف
+district	Ghiyathi	Code: 01030300 | Arabic: غِيَّاثِي
+district	Al Ruways	Code: 01030310 | Arabic: مدينة الرويس الصناعية
+district	Al Mirayr	Code: 01030320 | Arabic: المِرَيْر
+district	Yaw Al Ghadar	Code: 01030330 | Arabic: يَو الغَدَر
+district	Bad' Al Mutaw'Ah	Code: 01030340 | Arabic: بَدْع المُطاوْعة
+district	Jabal Al Dhannah	Code: 01030350 | Arabic: مدينة الظنة
+district	Al Jazeerah	Code: 01030360 | Arabic: الجَزيرَة
+district	Um Al Ashtan	Code: 01030370 | Arabic: أم الأشطان
+district	Al Hamra	Code: 01030380 | Arabic: الحَمْرَا
+district	Al Shuweehat	Code: 01030390 | Arabic: الشُّوِيهَات
+district	Barakah	Code: 01030400 | Arabic: بَرَاكَة
+district	Sabkhat Matti	Code: 01030410 | Arabic: سَبْخَة مَطِّي
+district	Delma	Code: 01030420 | Arabic: دلما
+district	Mahmiyyat Al Suqour	Code: 01030430 | Arabic: مَحْمِيَّة الصُّقُور
+district	Al Wuhaydah	Code: 01030440 | Arabic: الوُهَيْدَة
+district	Al Sila'	Code: 01030450 | Arabic: السِّلَع
+district	Ras Mshayrib	Code: 01030460 | Arabic: رَأس مْشَيْرِب
+district	Al Ghuweifat	Code: 01030470 | Arabic: الغويفات
+district	Ras Ghumeis	Code: 01030480 | Arabic: رأس غُمِيس

--- a/reviewer-ui/package-lock.json
+++ b/reviewer-ui/package-lock.json
@@ -8,11 +8,9 @@
       "name": "reviewer-ui",
       "version": "0.1.0",
       "dependencies": {
-        "@emotion/react": "^11.11.4",
-        "@emotion/styled": "^11.11.5",
-        "@mui/icons-material": "^5.15.17",
-        "@mui/material": "^5.15.17",
+        "bootstrap": "^5.3.3",
         "react": "^18.2.0",
+        "react-bootstrap": "^2.10.2",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.23.0"
       },
@@ -28,6 +26,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
       "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.27.1",
@@ -83,6 +82,7 @@
       "version": "7.28.3",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.3.tgz",
       "integrity": "sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.28.3",
@@ -116,6 +116,7 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
       "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -125,6 +126,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
       "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.27.1",
@@ -166,6 +168,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -175,6 +178,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
       "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -208,6 +212,7 @@
       "version": "7.28.4",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
       "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.28.4"
@@ -264,6 +269,7 @@
       "version": "7.27.2",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
       "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
@@ -278,6 +284,7 @@
       "version": "7.28.4",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.4.tgz",
       "integrity": "sha512-YEzuboP2qvQavAcjgQNVgsvHIDv6ZpwXvcvjmyySP2DIMuByS/6ioU5G9pYrWHM6T2YDfc7xga9iNzYOs12CFQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
@@ -296,6 +303,7 @@
       "version": "7.28.4",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
       "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -304,158 +312,6 @@
       "engines": {
         "node": ">=6.9.0"
       }
-    },
-    "node_modules/@emotion/babel-plugin": {
-      "version": "11.13.5",
-      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
-      "integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.16.7",
-        "@babel/runtime": "^7.18.3",
-        "@emotion/hash": "^0.9.2",
-        "@emotion/memoize": "^0.9.0",
-        "@emotion/serialize": "^1.3.3",
-        "babel-plugin-macros": "^3.1.0",
-        "convert-source-map": "^1.5.0",
-        "escape-string-regexp": "^4.0.0",
-        "find-root": "^1.1.0",
-        "source-map": "^0.5.7",
-        "stylis": "4.2.0"
-      }
-    },
-    "node_modules/@emotion/babel-plugin/node_modules/convert-source-map": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
-      "license": "MIT"
-    },
-    "node_modules/@emotion/cache": {
-      "version": "11.14.0",
-      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
-      "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
-      "license": "MIT",
-      "dependencies": {
-        "@emotion/memoize": "^0.9.0",
-        "@emotion/sheet": "^1.4.0",
-        "@emotion/utils": "^1.4.2",
-        "@emotion/weak-memoize": "^0.4.0",
-        "stylis": "4.2.0"
-      }
-    },
-    "node_modules/@emotion/hash": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
-      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
-      "license": "MIT"
-    },
-    "node_modules/@emotion/is-prop-valid": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
-      "integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
-      "license": "MIT",
-      "dependencies": {
-        "@emotion/memoize": "^0.9.0"
-      }
-    },
-    "node_modules/@emotion/memoize": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
-      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
-      "license": "MIT"
-    },
-    "node_modules/@emotion/react": {
-      "version": "11.14.0",
-      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
-      "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.18.3",
-        "@emotion/babel-plugin": "^11.13.5",
-        "@emotion/cache": "^11.14.0",
-        "@emotion/serialize": "^1.3.3",
-        "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
-        "@emotion/utils": "^1.4.2",
-        "@emotion/weak-memoize": "^0.4.0",
-        "hoist-non-react-statics": "^3.3.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@emotion/serialize": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
-      "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
-      "license": "MIT",
-      "dependencies": {
-        "@emotion/hash": "^0.9.2",
-        "@emotion/memoize": "^0.9.0",
-        "@emotion/unitless": "^0.10.0",
-        "@emotion/utils": "^1.4.2",
-        "csstype": "^3.0.2"
-      }
-    },
-    "node_modules/@emotion/sheet": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
-      "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
-      "license": "MIT"
-    },
-    "node_modules/@emotion/styled": {
-      "version": "11.14.1",
-      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
-      "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.18.3",
-        "@emotion/babel-plugin": "^11.13.5",
-        "@emotion/is-prop-valid": "^1.3.0",
-        "@emotion/serialize": "^1.3.3",
-        "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
-        "@emotion/utils": "^1.4.2"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.0.0-rc.0",
-        "react": ">=16.8.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@emotion/unitless": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
-      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
-      "license": "MIT"
-    },
-    "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz",
-      "integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": ">=16.8.0"
-      }
-    },
-    "node_modules/@emotion/utils": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
-      "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
-      "license": "MIT"
-    },
-    "node_modules/@emotion/weak-memoize": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
-      "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
-      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
@@ -852,6 +708,7 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -873,6 +730,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -882,241 +740,18 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
-    "node_modules/@mui/core-downloads-tracker": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.18.0.tgz",
-      "integrity": "sha512-jbhwoQ1AY200PSSOrNXmrFCaSDSJWP7qk6urkTmIirvRXDROkqe+QwcLlUiw/PrREwsIF/vm3/dAXvjlMHF0RA==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      }
-    },
-    "node_modules/@mui/icons-material": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.18.0.tgz",
-      "integrity": "sha512-1s0vEZj5XFXDMmz3Arl/R7IncFqJ+WQ95LDp1roHWGDE2oCO3IS4/hmiOv1/8SD9r6B7tv9GLiqVZYHo+6PkTg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.23.9"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@mui/material": "^5.0.0",
-        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/material": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.18.0.tgz",
-      "integrity": "sha512-bbH/HaJZpFtXGvWg3TsBWG4eyt3gah3E7nCNU8GLyRjVoWcA91Vm/T+sjHfUcwgJSw9iLtucfHBoq+qW/T30aA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.23.9",
-        "@mui/core-downloads-tracker": "^5.18.0",
-        "@mui/system": "^5.18.0",
-        "@mui/types": "~7.2.15",
-        "@mui/utils": "^5.17.1",
-        "@popperjs/core": "^2.11.8",
-        "@types/react-transition-group": "^4.4.10",
-        "clsx": "^2.1.0",
-        "csstype": "^3.1.3",
-        "prop-types": "^15.8.1",
-        "react-is": "^19.0.0",
-        "react-transition-group": "^4.4.5"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.5.0",
-        "@emotion/styled": "^11.3.0",
-        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/react": {
-          "optional": true
-        },
-        "@emotion/styled": {
-          "optional": true
-        },
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/private-theming": {
-      "version": "5.17.1",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.17.1.tgz",
-      "integrity": "sha512-XMxU0NTYcKqdsG8LRmSoxERPXwMbp16sIXPcLVgLGII/bVNagX0xaheWAwFv8+zDK7tI3ajllkuD3GZZE++ICQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.23.9",
-        "@mui/utils": "^5.17.1",
-        "prop-types": "^15.8.1"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/styled-engine": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.18.0.tgz",
-      "integrity": "sha512-BN/vKV/O6uaQh2z5rXV+MBlVrEkwoS/TK75rFQ2mjxA7+NBo8qtTAOA4UaM0XeJfn7kh2wZ+xQw2HAx0u+TiBg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.23.9",
-        "@emotion/cache": "^11.13.5",
-        "@emotion/serialize": "^1.3.3",
-        "csstype": "^3.1.3",
-        "prop-types": "^15.8.1"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.4.1",
-        "@emotion/styled": "^11.3.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/react": {
-          "optional": true
-        },
-        "@emotion/styled": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/system": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.18.0.tgz",
-      "integrity": "sha512-ojZGVcRWqWhu557cdO3pWHloIGJdzVtxs3rk0F9L+x55LsUjcMUVkEhiF7E4TMxZoF9MmIHGGs0ZX3FDLAf0Xw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.23.9",
-        "@mui/private-theming": "^5.17.1",
-        "@mui/styled-engine": "^5.18.0",
-        "@mui/types": "~7.2.15",
-        "@mui/utils": "^5.17.1",
-        "clsx": "^2.1.0",
-        "csstype": "^3.1.3",
-        "prop-types": "^15.8.1"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.5.0",
-        "@emotion/styled": "^11.3.0",
-        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/react": {
-          "optional": true
-        },
-        "@emotion/styled": {
-          "optional": true
-        },
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/types": {
-      "version": "7.2.24",
-      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.24.tgz",
-      "integrity": "sha512-3c8tRt/CbWZ+pEg7QpSwbdxOk36EfmhbKf6AGZsD1EcLDLTSZoxxJ86FVtcjxvjuhdyBiWKSTGZFaXCnidO2kw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/utils": {
-      "version": "5.17.1",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.17.1.tgz",
-      "integrity": "sha512-jEZ8FTqInt2WzxDV8bhImWBqeQRD99c/id/fq83H0ER9tFl+sfZlaAoCdznGvbSQQ9ividMxqSV2c7cC1vBcQg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.23.9",
-        "@mui/types": "~7.2.15",
-        "@types/prop-types": "^15.7.12",
-        "clsx": "^2.1.1",
-        "prop-types": "^15.8.1",
-        "react-is": "^19.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
       }
     },
     "node_modules/@popperjs/core": {
@@ -1129,6 +764,21 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
+    "node_modules/@react-aria/ssr": {
+      "version": "3.9.10",
+      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.10.tgz",
+      "integrity": "sha512-hvTm77Pf+pMBhuBm760Li0BVIO38jv1IBws1xFm1NoL26PU+fe+FMW5+VZWyANR6nYL65joaJKZqOdTQMkO9IQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      },
+      "engines": {
+        "node": ">= 12"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
     "node_modules/@remix-run/router": {
       "version": "1.23.0",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
@@ -1136,6 +786,60 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@restart/hooks": {
+      "version": "0.4.16",
+      "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.4.16.tgz",
+      "integrity": "sha512-f7aCv7c+nU/3mF7NWLtVVr0Ra80RqsO89hO72r+Y/nvQr5+q0UFGkocElTH6MJApvReVh6JHUFYn2cw1WdHF3w==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@restart/ui": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@restart/ui/-/ui-1.9.4.tgz",
+      "integrity": "sha512-N4C7haUc3vn4LTwVUPlkJN8Ach/+yIMvRuTVIhjilNHqegY60SGLrzud6errOMNJwSnmYFnt1J0H/k8FE3A4KA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.0",
+        "@popperjs/core": "^2.11.8",
+        "@react-aria/ssr": "^3.5.0",
+        "@restart/hooks": "^0.5.0",
+        "@types/warning": "^3.0.3",
+        "dequal": "^2.0.3",
+        "dom-helpers": "^5.2.0",
+        "uncontrollable": "^8.0.4",
+        "warning": "^4.0.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.14.0",
+        "react-dom": ">=16.14.0"
+      }
+    },
+    "node_modules/@restart/ui/node_modules/@restart/hooks": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.5.1.tgz",
+      "integrity": "sha512-EMoH04NHS1pbn07iLTjIjgttuqb7qu4+/EyhAx27MHpoENcB2ZdSsLTNxmKD+WEPnZigo62Qc8zjGnNxoSE/5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@restart/ui/node_modules/uncontrollable": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-8.0.4.tgz",
+      "integrity": "sha512-ulRWYWHvscPFc0QQXvyJjY6LIXU56f0h8pQFvhxiKk5V1fcI8gp9Ht9leVAhrVjzqMw0BgjspBINx9r6oyJUvQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.14.0"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -1453,6 +1157,15 @@
         "win32"
       ]
     },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
+      "integrity": "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1505,12 +1218,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/parse-json": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
-      "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
-      "license": "MIT"
-    },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
@@ -1546,6 +1253,12 @@
         "@types/react": "*"
       }
     },
+    "node_modules/@types/warning": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.3.tgz",
+      "integrity": "sha512-D1XC7WK8K+zZEveUPY+cf4+kgauk8N4eHr/XIHXGlGYkHLud6hK9lYfZk1ry1TNh798cZUCgb6MqGEG8DkJt6Q==",
+      "license": "MIT"
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
@@ -1567,21 +1280,6 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
-    "node_modules/babel-plugin-macros": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
-      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "cosmiconfig": "^7.0.0",
-        "resolve": "^1.19.0"
-      },
-      "engines": {
-        "node": ">=10",
-        "npm": ">=6"
-      }
-    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.8.6",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.6.tgz",
@@ -1590,6 +1288,25 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/bootstrap": {
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.8.tgz",
+      "integrity": "sha512-HP1SZDqaLDPwsNiqRqi5NcP0SSXciX2s9E+RyqJIIqGo+vJeN5AJVM98CXmW/Wux0nQ5L7jeWUdplCEf0Ee+tg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/twbs"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/bootstrap"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "@popperjs/core": "^2.11.8"
       }
     },
     "node_modules/browserslist": {
@@ -1626,15 +1343,6 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
-    "node_modules/callsites": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001745",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001745.tgz",
@@ -1656,14 +1364,11 @@
       ],
       "license": "CC-BY-4.0"
     },
-    "node_modules/clsx": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
-      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -1671,22 +1376,6 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/cosmiconfig": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
-      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/parse-json": "^4.0.0",
-        "import-fresh": "^3.2.1",
-        "parse-json": "^5.0.0",
-        "path-type": "^4.0.0",
-        "yaml": "^1.10.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/csstype": {
       "version": "3.1.3",
@@ -1698,6 +1387,7 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -1709,6 +1399,15 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/dom-helpers": {
@@ -1727,15 +1426,6 @@
       "integrity": "sha512-qKm55ic6nbEmagFlTFczML33rF90aU+WtrJ9MdTCThrcvDNdUHN4p6QfVN78U06ZmguqXIyMPyYhw2TrbDUwPQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/error-ex": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
-      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
-      "license": "MIT",
-      "dependencies": {
-        "is-arrayish": "^0.2.1"
-      }
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -1786,24 +1476,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/find-root": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
-      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
-      "license": "MIT"
-    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1819,15 +1491,6 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/function-bind": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -1838,68 +1501,13 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "license": "MIT",
       "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/hoist-non-react-statics": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "react-is": "^16.7.0"
-      }
-    },
-    "node_modules/hoist-non-react-statics/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT"
-    },
-    "node_modules/import-fresh": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
-      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
-      "license": "MIT",
-      "dependencies": {
-        "parent-module": "^1.0.0",
-        "resolve-from": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-arrayish": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "license": "MIT"
-    },
-    "node_modules/is-core-module": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
-      "license": "MIT",
-      "dependencies": {
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/js-tokens": {
@@ -1912,6 +1520,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
@@ -1919,12 +1528,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/json-parse-even-better-errors": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "license": "MIT"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -1938,12 +1541,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/lines-and-columns": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "license": "MIT"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -1971,6 +1568,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -2008,55 +1606,11 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/parent-module": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "license": "MIT",
-      "dependencies": {
-        "callsites": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/parse-json": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.0.0",
-        "error-ex": "^1.3.1",
-        "json-parse-even-better-errors": "^2.3.0",
-        "lines-and-columns": "^1.1.6"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/path-parse": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "license": "MIT"
-    },
-    "node_modules/path-type": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/postcss": {
@@ -2099,6 +1653,25 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/prop-types-extra": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/prop-types-extra/-/prop-types-extra-1.1.1.tgz",
+      "integrity": "sha512-59+AHNnHYCdiC+vMwY52WmvP5dM3QLeoumYuEyceQDi9aEhtwN9zIQ2ZNo25sMyXnbh32h+P1ezDsUpUH3JAew==",
+      "license": "MIT",
+      "dependencies": {
+        "react-is": "^16.3.2",
+        "warning": "^4.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=0.14.0"
+      }
+    },
+    "node_modules/prop-types-extra/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
     "node_modules/prop-types/node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -2117,6 +1690,37 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-bootstrap": {
+      "version": "2.10.10",
+      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-2.10.10.tgz",
+      "integrity": "sha512-gMckKUqn8aK/vCnfwoBpBVFUGT9SVQxwsYrp9yDHt0arXMamxALerliKBxr1TPbntirK/HGrUAHYbAeQTa9GHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.24.7",
+        "@restart/hooks": "^0.4.9",
+        "@restart/ui": "^1.9.4",
+        "@types/prop-types": "^15.7.12",
+        "@types/react-transition-group": "^4.4.6",
+        "classnames": "^2.3.2",
+        "dom-helpers": "^5.2.1",
+        "invariant": "^2.2.4",
+        "prop-types": "^15.8.1",
+        "prop-types-extra": "^1.1.0",
+        "react-transition-group": "^4.4.5",
+        "uncontrollable": "^7.2.1",
+        "warning": "^4.0.3"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.8",
+        "react": ">=16.14.0",
+        "react-dom": ">=16.14.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
@@ -2130,10 +1734,10 @@
         "react": "^18.3.1"
       }
     },
-    "node_modules/react-is": {
-      "version": "19.1.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.1.tgz",
-      "integrity": "sha512-tr41fA15Vn8p4X9ntI+yCyeGSf1TlYaY5vlTZfQmeLBrFo3psOPX6HhTDnFNL9uj3EhP0KAQ80cugCl4b4BERA==",
+    "node_modules/react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
       "license": "MIT"
     },
     "node_modules/react-refresh": {
@@ -2192,35 +1796,6 @@
       "peerDependencies": {
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
-      }
-    },
-    "node_modules/resolve": {
-      "version": "1.22.10",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
-      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
-      "license": "MIT",
-      "dependencies": {
-        "is-core-module": "^2.16.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/resolve-from": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/rollup": {
@@ -2284,15 +1859,6 @@
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2303,23 +1869,11 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/stylis": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
-      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
-      "license": "MIT"
-    },
-    "node_modules/supports-preserve-symlinks-flag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/typescript": {
       "version": "5.9.2",
@@ -2333,6 +1887,21 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/uncontrollable": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-7.2.1.tgz",
+      "integrity": "sha512-svtcfoTADIB0nT9nltgjujTi7BzVmwjZClOmskKu/E8FW9BXzg9os8OLr4f8Dlnk0rYWJIWr4wv9eKUXiQvQwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.6.3",
+        "@types/react": ">=16.9.11",
+        "invariant": "^2.2.4",
+        "react-lifecycles-compat": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react": ">=15.0.0"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -2426,21 +1995,21 @@
         }
       }
     },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 6"
-      }
     }
   }
 }

--- a/reviewer-ui/package.json
+++ b/reviewer-ui/package.json
@@ -9,11 +9,9 @@
     "preview": "vite preview --host 0.0.0.0 --port 4173"
   },
   "dependencies": {
-    "@emotion/react": "^11.11.4",
-    "@emotion/styled": "^11.11.5",
-    "@mui/icons-material": "^5.15.17",
-    "@mui/material": "^5.15.17",
+    "bootstrap": "^5.3.3",
     "react": "^18.2.0",
+    "react-bootstrap": "^2.10.2",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.23.0"
   },

--- a/reviewer-ui/src/main.tsx
+++ b/reviewer-ui/src/main.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import 'bootstrap/dist/css/bootstrap.min.css';
+import './styles.css';
 import App from './App';
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>

--- a/reviewer-ui/src/pages/CanonicalLibraryPage.tsx
+++ b/reviewer-ui/src/pages/CanonicalLibraryPage.tsx
@@ -1,0 +1,475 @@
+import { useMemo, useState } from 'react';
+import {
+  Badge,
+  Button,
+  Card,
+  Col,
+  Form,
+  InputGroup,
+  Modal,
+  Row,
+  Spinner,
+  Table,
+} from 'react-bootstrap';
+
+import {
+  createCanonicalValue,
+  deleteCanonicalValue,
+  updateCanonicalValue,
+} from '../api';
+import { useAppState } from '../state/AppStateContext';
+import type {
+  CanonicalValue,
+  CanonicalValueUpdatePayload,
+  ToastMessage,
+} from '../types';
+
+interface CanonicalLibraryPageProps {
+  onToast: (toast: ToastMessage) => void;
+}
+
+interface BulkEntry {
+  dimension: string;
+  canonical_label: string;
+  description?: string;
+}
+
+function parseBulkEntries(raw: string, fallbackDimension: string): BulkEntry[] {
+  const lines = raw
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !/^#/.test(line));
+
+  const entries: BulkEntry[] = [];
+
+  for (const line of lines) {
+    const parts = line
+      .split(/\t|\s{2,}|,/)
+      .map((part) => part.trim())
+      .filter((part) => part.length > 0);
+
+    if (parts.length < 2) {
+      continue;
+    }
+
+    let [dimension, label, ...rest] = parts;
+
+    if (!dimension && fallbackDimension) {
+      dimension = fallbackDimension;
+    }
+
+    if (!dimension || !label) {
+      continue;
+    }
+
+    const description = rest.length ? rest.join(' — ') : undefined;
+
+    entries.push({
+      dimension,
+      canonical_label: label,
+      description,
+    });
+  }
+
+  return entries;
+}
+
+function buildCsv(rows: CanonicalValue[]): string {
+  const header = ['Dimension', 'Canonical Label', 'Description'];
+  const encodedRows = rows.map((row) => [row.dimension, row.canonical_label, row.description ?? '']);
+  return [header, ...encodedRows]
+    .map((columns) =>
+      columns
+        .map((column) => {
+          const value = column.replaceAll('"', '""');
+          return `"${value}"`;
+        })
+        .join(','),
+    )
+    .join('\n');
+}
+
+const CanonicalLibraryPage = ({ onToast }: CanonicalLibraryPageProps) => {
+  const { canonicalValues, updateCanonicalValues } = useAppState();
+  const [searchTerm, setSearchTerm] = useState('');
+  const [dimensionFilter, setDimensionFilter] = useState('all');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [showEditor, setShowEditor] = useState(false);
+  const [editorDraft, setEditorDraft] = useState<CanonicalValueUpdatePayload>({});
+  const [editingTarget, setEditingTarget] = useState<CanonicalValue | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<CanonicalValue | null>(null);
+  const [showBulkModal, setShowBulkModal] = useState(false);
+  const [bulkDimension, setBulkDimension] = useState('');
+  const [bulkText, setBulkText] = useState('');
+
+  const dimensions = useMemo(() => {
+    return Array.from(new Set(canonicalValues.map((value) => value.dimension))).sort();
+  }, [canonicalValues]);
+
+  const filteredValues = useMemo(() => {
+    const query = searchTerm.trim().toLowerCase();
+    return canonicalValues.filter((value) => {
+      const dimensionMatch = dimensionFilter === 'all' || value.dimension === dimensionFilter;
+      if (!dimensionMatch) return false;
+      if (!query) return true;
+      return (
+        value.canonical_label.toLowerCase().includes(query) ||
+        value.dimension.toLowerCase().includes(query) ||
+        (value.description ?? '').toLowerCase().includes(query)
+      );
+    });
+  }, [canonicalValues, dimensionFilter, searchTerm]);
+
+  const openCreateModal = () => {
+    setEditingTarget(null);
+    setEditorDraft({ dimension: '', canonical_label: '', description: '' });
+    setShowEditor(true);
+  };
+
+  const openEditModal = (value: CanonicalValue) => {
+    setEditingTarget(value);
+    setEditorDraft({
+      dimension: value.dimension,
+      canonical_label: value.canonical_label,
+      description: value.description ?? '',
+    });
+    setShowEditor(true);
+  };
+
+  const handleEditorSubmit = async () => {
+    if (!editorDraft.dimension || !editorDraft.canonical_label) {
+      onToast({ type: 'error', content: 'Dimension and canonical label are required.' });
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      if (editingTarget) {
+        const updated = await updateCanonicalValue(editingTarget.id, editorDraft);
+        updateCanonicalValues((prev) =>
+          prev.map((item) => (item.id === updated.id ? updated : item)),
+        );
+        onToast({ type: 'success', content: 'Canonical value updated.' });
+      } else {
+        const created = await createCanonicalValue(editorDraft as CanonicalValueUpdatePayload);
+        updateCanonicalValues((prev) => [...prev, created]);
+        onToast({ type: 'success', content: 'Canonical value created.' });
+      }
+      setShowEditor(false);
+    } catch (error: unknown) {
+      console.error(error);
+      onToast({ type: 'error', content: 'Unable to save canonical value.' });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!deleteTarget) return;
+    setIsSubmitting(true);
+    try {
+      await deleteCanonicalValue(deleteTarget.id);
+      updateCanonicalValues((prev) => prev.filter((item) => item.id !== deleteTarget.id));
+      onToast({ type: 'success', content: 'Canonical value removed.' });
+      setDeleteTarget(null);
+    } catch (error: unknown) {
+      console.error(error);
+      onToast({ type: 'error', content: 'Unable to delete canonical value.' });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleExport = () => {
+    const csv = buildCsv(filteredValues);
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = 'canonical-values.csv';
+    anchor.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleBulkImport = async () => {
+    if (!bulkText.trim()) {
+      onToast({ type: 'error', content: 'Paste canonical rows to import.' });
+      return;
+    }
+
+    const entries = parseBulkEntries(bulkText, bulkDimension);
+
+    if (!entries.length) {
+      onToast({ type: 'error', content: 'No valid rows detected. Ensure each row has at least a dimension and label.' });
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      const created: CanonicalValue[] = [];
+      for (const entry of entries) {
+        const canonical = await createCanonicalValue(entry);
+        created.push(canonical);
+      }
+      if (created.length) {
+        updateCanonicalValues((prev) => [...prev, ...created]);
+      }
+      onToast({ type: 'success', content: `Imported ${created.length} canonical value(s).` });
+      setShowBulkModal(false);
+      setBulkText('');
+      setBulkDimension('');
+    } catch (error: unknown) {
+      console.error(error);
+      onToast({ type: 'error', content: 'Unable to import canonical values.' });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="d-flex flex-column gap-4" aria-label="Canonical library">
+      <Card className="card-section">
+        <Card.Body className="d-flex flex-column gap-4">
+          <div className="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center gap-3">
+            <div>
+              <Card.Title as="h1" className="section-heading h4 mb-1">
+                Canonical library
+              </Card.Title>
+              <Card.Text className="text-body-secondary mb-0">
+                Curate golden records across every dimension. Use filters to focus on a single taxonomy or search by keyword.
+              </Card.Text>
+            </div>
+            <div className="d-flex flex-wrap gap-2">
+              <Button variant="primary" onClick={openCreateModal}>
+                New canonical value
+              </Button>
+              <Button variant="outline-primary" onClick={() => setShowBulkModal(true)}>
+                Bulk import
+              </Button>
+              <Button variant="outline-secondary" onClick={handleExport}>
+                Export CSV
+              </Button>
+            </div>
+          </div>
+
+          <Row className="g-3">
+            <Col md={4}>
+              <Form.Group controlId="dimension-filter">
+                <Form.Label>Dimension</Form.Label>
+                <Form.Select value={dimensionFilter} onChange={(event) => setDimensionFilter(event.target.value)}>
+                  <option value="all">All dimensions</option>
+                  {dimensions.map((dimension) => (
+                    <option key={dimension} value={dimension}>
+                      {dimension}
+                    </option>
+                  ))}
+                </Form.Select>
+              </Form.Group>
+            </Col>
+            <Col md={8}>
+              <Form.Group controlId="search-canonical">
+                <Form.Label>Search</Form.Label>
+                <InputGroup>
+                  <InputGroup.Text>🔍</InputGroup.Text>
+                  <Form.Control
+                    type="search"
+                    placeholder="Search by label, dimension, or description"
+                    value={searchTerm}
+                    onChange={(event) => setSearchTerm(event.target.value)}
+                  />
+                </InputGroup>
+              </Form.Group>
+            </Col>
+          </Row>
+
+          <div className="table-responsive">
+            <Table striped hover className="align-middle table-nowrap">
+              <thead>
+                <tr>
+                  <th>Canonical label</th>
+                  <th>Dimension</th>
+                  <th>Description</th>
+                  <th className="text-end">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {filteredValues.length === 0 && (
+                  <tr>
+                    <td colSpan={4} className="text-center text-body-secondary py-4">
+                      No canonical values match the current filters.
+                    </td>
+                  </tr>
+                )}
+                {filteredValues.map((value) => (
+                  <tr key={value.id}>
+                    <td className="fw-semibold">{value.canonical_label}</td>
+                    <td>
+                      <Badge bg="info" text="dark">
+                        {value.dimension}
+                      </Badge>
+                    </td>
+                    <td>{value.description || '—'}</td>
+                    <td className="text-end">
+                      <div className="d-inline-flex gap-2">
+                        <Button
+                          size="sm"
+                          variant="outline-primary"
+                          onClick={() => openEditModal(value)}
+                        >
+                          Edit
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="outline-danger"
+                          onClick={() => setDeleteTarget(value)}
+                        >
+                          Delete
+                        </Button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </Table>
+          </div>
+        </Card.Body>
+      </Card>
+
+      <Modal show={showEditor} onHide={() => setShowEditor(false)} backdrop="static" centered>
+        <Modal.Header closeButton>
+          <Modal.Title>{editingTarget ? 'Edit canonical value' : 'New canonical value'}</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <Form className="d-flex flex-column gap-3">
+            <Form.Group controlId="editor-dimension">
+              <Form.Label>Dimension</Form.Label>
+              <Form.Control
+                type="text"
+                placeholder="e.g. region"
+                value={editorDraft.dimension ?? ''}
+                onChange={(event) =>
+                  setEditorDraft((draft) => ({ ...draft, dimension: event.target.value }))
+                }
+                required
+              />
+            </Form.Group>
+            <Form.Group controlId="editor-label">
+              <Form.Label>Canonical label</Form.Label>
+              <Form.Control
+                type="text"
+                value={editorDraft.canonical_label ?? ''}
+                onChange={(event) =>
+                  setEditorDraft((draft) => ({ ...draft, canonical_label: event.target.value }))
+                }
+                required
+              />
+            </Form.Group>
+            <Form.Group controlId="editor-description">
+              <Form.Label>Description</Form.Label>
+              <Form.Control
+                as="textarea"
+                rows={3}
+                placeholder="Optional description"
+                value={editorDraft.description ?? ''}
+                onChange={(event) =>
+                  setEditorDraft((draft) => ({ ...draft, description: event.target.value }))
+                }
+              />
+            </Form.Group>
+          </Form>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button variant="outline-secondary" onClick={() => setShowEditor(false)}>
+            Cancel
+          </Button>
+          <Button variant="primary" onClick={() => void handleEditorSubmit()} disabled={isSubmitting}>
+            {isSubmitting ? (
+              <span className="d-inline-flex align-items-center gap-2">
+                <Spinner animation="border" size="sm" role="status" aria-hidden="true" />
+                Saving…
+              </span>
+            ) : (
+              'Save'
+            )}
+          </Button>
+        </Modal.Footer>
+      </Modal>
+
+      <Modal show={Boolean(deleteTarget)} onHide={() => setDeleteTarget(null)} centered>
+        <Modal.Header closeButton>
+          <Modal.Title>Delete canonical value</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          Are you sure you want to delete “{deleteTarget?.canonical_label}” from the
+          {' '}
+          <strong>{deleteTarget?.dimension}</strong> dimension?
+        </Modal.Body>
+        <Modal.Footer>
+          <Button variant="outline-secondary" onClick={() => setDeleteTarget(null)}>
+            Cancel
+          </Button>
+          <Button variant="danger" onClick={() => void handleDelete()} disabled={isSubmitting}>
+            {isSubmitting ? (
+              <span className="d-inline-flex align-items-center gap-2">
+                <Spinner animation="border" size="sm" role="status" aria-hidden="true" />
+                Deleting…
+              </span>
+            ) : (
+              'Delete'
+            )}
+          </Button>
+        </Modal.Footer>
+      </Modal>
+
+      <Modal show={showBulkModal} onHide={() => setShowBulkModal(false)} size="lg" centered>
+        <Modal.Header closeButton>
+          <Modal.Title>Bulk import canonical values</Modal.Title>
+        </Modal.Header>
+        <Modal.Body className="d-flex flex-column gap-3">
+          <p className="mb-0 text-body-secondary">
+            Paste tab- or comma-separated rows. The importer expects columns in the order
+            {' '}
+            <code>dimension</code>, <code>canonical label</code>, and optional description fields (such as codes or translations).
+            Empty dimension cells inherit the default dimension below.
+          </p>
+          <Form.Group controlId="bulk-dimension">
+            <Form.Label>Default dimension (optional)</Form.Label>
+            <Form.Control
+              type="text"
+              placeholder="Use when the pasted rows omit a dimension column"
+              value={bulkDimension}
+              onChange={(event) => setBulkDimension(event.target.value)}
+            />
+          </Form.Group>
+          <Form.Group controlId="bulk-rows">
+            <Form.Label>Rows to import</Form.Label>
+            <Form.Control
+              as="textarea"
+              rows={10}
+              placeholder={`Example:\nregion\tAbu Dhabi Emirate\tCode 01\tإمارة أبوظبي`}
+              value={bulkText}
+              onChange={(event) => setBulkText(event.target.value)}
+            />
+          </Form.Group>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button variant="outline-secondary" onClick={() => setShowBulkModal(false)}>
+            Cancel
+          </Button>
+          <Button variant="primary" onClick={() => void handleBulkImport()} disabled={isSubmitting}>
+            {isSubmitting ? (
+              <span className="d-inline-flex align-items-center gap-2">
+                <Spinner animation="border" size="sm" role="status" aria-hidden="true" />
+                Importing…
+              </span>
+            ) : (
+              'Import rows'
+            )}
+          </Button>
+        </Modal.Footer>
+      </Modal>
+    </div>
+  );
+};
+
+export default CanonicalLibraryPage;

--- a/reviewer-ui/src/pages/FieldMappingsPage.tsx
+++ b/reviewer-ui/src/pages/FieldMappingsPage.tsx
@@ -1,33 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import AddCircleRoundedIcon from '@mui/icons-material/AddCircleRounded';
-import DeleteRoundedIcon from '@mui/icons-material/DeleteRounded';
-import EditRoundedIcon from '@mui/icons-material/EditRounded';
-import SaveRoundedIcon from '@mui/icons-material/SaveRounded';
-import UploadRoundedIcon from '@mui/icons-material/UploadRounded';
-import {
-  Box,
-  Button,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
-  FormControl,
-  Grid,
-  IconButton,
-  InputLabel,
-  MenuItem,
-  Paper,
-  Select,
-  Stack,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  TextField,
-  Typography,
-} from '@mui/material';
+import { Button, Card, Col, Form, Modal, Row, Spinner, Table } from 'react-bootstrap';
 
 import {
   createFieldMapping,
@@ -64,9 +36,11 @@ const FieldMappingsPage = ({ onToast }: FieldMappingsPageProps) => {
   const [mappings, setMappings] = useState<SourceFieldMapping[]>([]);
   const [loadingMappings, setLoadingMappings] = useState(false);
   const [creating, setCreating] = useState(false);
-  const [form, setForm] = useState<SourceFieldMappingPayload>(initialMapping);
+  const [updating, setUpdating] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [form, setForm] = useState<SourceFieldMappingPayload>({ ...initialMapping });
   const [editing, setEditing] = useState<SourceFieldMapping | null>(null);
-  const [editForm, setEditForm] = useState<SourceFieldMappingPayload>(initialMapping);
+  const [editForm, setEditForm] = useState<SourceFieldMappingPayload>({ ...initialMapping });
   const [deleteTarget, setDeleteTarget] = useState<SourceFieldMapping | null>(null);
   const [sampleTable, setSampleTable] = useState('');
   const [sampleField, setSampleField] = useState('');
@@ -89,22 +63,25 @@ const FieldMappingsPage = ({ onToast }: FieldMappingsPageProps) => {
       }
     } catch (error) {
       console.error(error);
-      onToast({ type: 'error', content: 'Failed to load connections' });
+      onToast({ type: 'error', content: 'Failed to load connections.' });
     }
   }, [onToast, selectedConnectionId]);
 
-  const loadMappings = useCallback(async (connectionId: number) => {
-    setLoadingMappings(true);
-    try {
-      const records = await fetchFieldMappings(connectionId);
-      setMappings(records);
-    } catch (error) {
-      console.error(error);
-      onToast({ type: 'error', content: 'Failed to load field mappings' });
-    } finally {
-      setLoadingMappings(false);
-    }
-  }, [onToast]);
+  const loadMappings = useCallback(
+    async (connectionId: number) => {
+      setLoadingMappings(true);
+      try {
+        const records = await fetchFieldMappings(connectionId);
+        setMappings(records);
+      } catch (error) {
+        console.error(error);
+        onToast({ type: 'error', content: 'Failed to load field mappings.' });
+      } finally {
+        setLoadingMappings(false);
+      }
+    },
+    [onToast],
+  );
 
   useEffect(() => {
     void loadConnections();
@@ -131,11 +108,11 @@ const FieldMappingsPage = ({ onToast }: FieldMappingsPageProps) => {
     try {
       const created = await createFieldMapping(selectedConnectionId, form);
       setMappings((prev) => [...prev, created]);
-      setForm(initialMapping);
-      onToast({ type: 'success', content: 'Field mapping created' });
+      setForm({ ...initialMapping });
+      onToast({ type: 'success', content: 'Field mapping created.' });
     } catch (error) {
       console.error(error);
-      onToast({ type: 'error', content: 'Unable to create field mapping' });
+      onToast({ type: 'error', content: 'Unable to create field mapping.' });
     } finally {
       setCreating(false);
     }
@@ -153,29 +130,33 @@ const FieldMappingsPage = ({ onToast }: FieldMappingsPageProps) => {
 
   const handleUpdate = async () => {
     if (!editing || !selectedConnectionId) return;
+    setUpdating(true);
     try {
       const updated = await updateFieldMapping(selectedConnectionId, editing.id, editForm);
       setMappings((prev) => prev.map((item) => (item.id === updated.id ? updated : item)));
-      onToast({ type: 'success', content: 'Field mapping updated' });
+      onToast({ type: 'success', content: 'Field mapping updated.' });
+      setEditing(null);
     } catch (error) {
       console.error(error);
-      onToast({ type: 'error', content: 'Unable to update mapping' });
-      return;
+      onToast({ type: 'error', content: 'Unable to update mapping.' });
     } finally {
-      setEditing(null);
+      setUpdating(false);
     }
   };
 
   const handleDelete = async () => {
     if (!deleteTarget || !selectedConnectionId) return;
+    setDeleting(true);
     try {
       await deleteFieldMapping(selectedConnectionId, deleteTarget.id);
       setMappings((prev) => prev.filter((item) => item.id !== deleteTarget.id));
-      onToast({ type: 'success', content: 'Field mapping removed' });
+      onToast({ type: 'success', content: 'Field mapping removed.' });
+      setDeleteTarget(null);
     } catch (error) {
       console.error(error);
-      onToast({ type: 'error', content: 'Unable to delete mapping' });
+      onToast({ type: 'error', content: 'Unable to delete mapping.' });
     } finally {
+      setDeleting(false);
       setDeleteTarget(null);
     }
   };
@@ -212,288 +193,306 @@ const FieldMappingsPage = ({ onToast }: FieldMappingsPageProps) => {
     setIngesting(true);
     try {
       await ingestSamples(selectedConnectionId, sampleTable, sampleField, values);
-      onToast({ type: 'success', content: 'Sample values ingested' });
+      onToast({ type: 'success', content: 'Sample values ingested.' });
       setSampleInput('');
     } catch (error) {
       console.error(error);
-      onToast({ type: 'error', content: 'Failed to ingest sample values' });
+      onToast({ type: 'error', content: 'Failed to ingest sample values.' });
     } finally {
       setIngesting(false);
     }
   };
 
   return (
-    <Stack spacing={4} component="section">
-      <Paper variant="outlined" sx={{ p: { xs: 3, md: 4 } }}>
-        <Stack spacing={2}>
-          <Box sx={{ display: 'flex', flexDirection: { xs: 'column', md: 'row' }, gap: 2 }}>
-            <Box sx={{ flexGrow: 1 }}>
-              <Typography variant="h6" fontWeight={600} gutterBottom>
+    <div className="d-flex flex-column gap-4">
+      <Card className="card-section">
+        <Card.Body className="d-flex flex-column gap-4">
+          <div className="d-flex flex-column flex-lg-row justify-content-between gap-3">
+            <div>
+              <Card.Title as="h1" className="section-heading h4 mb-1">
                 Map source fields to reference dimensions
-              </Typography>
-              <Typography variant="body2" color="text.secondary">
-                Define which source fields feed each reference dataset. These mappings power downstream match statistics and reviewer workflows.
-              </Typography>
-            </Box>
-            <FormControl size="small" sx={{ minWidth: 220 }}>
-              <InputLabel id="connection-select-label">Connection</InputLabel>
-              <Select
-                labelId="connection-select-label"
-                label="Connection"
+              </Card.Title>
+              <Card.Text className="text-body-secondary mb-0">
+                Define how source metadata populates canonical domains. Mappings power downstream insights and reviewer workflows.
+              </Card.Text>
+            </div>
+            <Form.Group controlId="connection-select">
+              <Form.Label>Active connection</Form.Label>
+              <Form.Select
                 value={selectedConnectionId}
-                onChange={(event) => setSelectedConnectionId(Number(event.target.value))}
+                onChange={(event) =>
+                  setSelectedConnectionId(event.target.value ? Number(event.target.value) : '')
+                }
               >
+                <option value="">Select connection</option>
                 {connections.map((connection) => (
-                  <MenuItem key={connection.id} value={connection.id}>
+                  <option key={connection.id} value={connection.id}>
                     {connection.name}
-                  </MenuItem>
+                  </option>
                 ))}
-              </Select>
-            </FormControl>
-          </Box>
+              </Form.Select>
+            </Form.Group>
+          </div>
 
-          <Grid container spacing={2} columns={{ xs: 1, sm: 6, md: 12 }}>
-            <Grid item xs={1} sm={3} md={3}>
-              <TextField
-                label="Source table"
+          <Form
+            onSubmit={(event) => {
+              event.preventDefault();
+              void handleCreate();
+            }}
+            className="row g-3"
+          >
+            <Form.Group as={Col} md={4} controlId="mapping-table">
+              <Form.Label>Source table</Form.Label>
+              <Form.Control
                 value={form.source_table}
                 onChange={(event) => setForm((prev) => ({ ...prev, source_table: event.target.value }))}
-                fullWidth
                 required
               />
-            </Grid>
-            <Grid item xs={1} sm={3} md={3}>
-              <TextField
-                label="Source field"
+            </Form.Group>
+            <Form.Group as={Col} md={4} controlId="mapping-field">
+              <Form.Label>Source field</Form.Label>
+              <Form.Control
                 value={form.source_field}
                 onChange={(event) => setForm((prev) => ({ ...prev, source_field: event.target.value }))}
-                fullWidth
                 required
               />
-            </Grid>
-            <Grid item xs={1} sm={3} md={3}>
-              <FormControl fullWidth>
-                <InputLabel id="dimension-select-label">Reference dimension</InputLabel>
-                <Select
-                  labelId="dimension-select-label"
-                  label="Reference dimension"
-                  value={form.ref_dimension}
-                  onChange={(event) => setForm((prev) => ({ ...prev, ref_dimension: event.target.value }))}
-                >
-                  {availableDimensions.map((dimension) => (
-                    <MenuItem key={dimension} value={dimension}>
-                      {dimension}
-                    </MenuItem>
-                  ))}
-                </Select>
-              </FormControl>
-            </Grid>
-            <Grid item xs={1} sm={6} md={3}>
-              <TextField
-                label="Description"
-                value={form.description ?? ''}
-                onChange={(event) => setForm((prev) => ({ ...prev, description: event.target.value }))}
-                fullWidth
-              />
-            </Grid>
-            <Grid item xs={1} sm={6} md={12}>
-              <Button
-                variant="contained"
-                startIcon={<AddCircleRoundedIcon />}
-                disabled={creating || !selectedConnectionId}
-                onClick={() => void handleCreate()}
+            </Form.Group>
+            <Form.Group as={Col} md={4} controlId="mapping-dimension">
+              <Form.Label>Reference dimension</Form.Label>
+              <Form.Select
+                value={form.ref_dimension}
+                onChange={(event) => setForm((prev) => ({ ...prev, ref_dimension: event.target.value }))}
+                required
               >
-                {creating ? 'Creating…' : 'Create mapping'}
-              </Button>
-            </Grid>
-          </Grid>
-        </Stack>
-      </Paper>
-
-      <Paper variant="outlined" sx={{ p: { xs: 3, md: 4 } }}>
-        <Typography variant="h6" fontWeight={600} gutterBottom>
-          Configured field mappings
-        </Typography>
-        <Typography variant="body2" color="text.secondary" gutterBottom>
-          Manage how source data flows into the reference data hub. These mappings drive sample ingestion, suggestions, and reconciliation insights.
-        </Typography>
-        <TableContainer>
-          {loadingMappings ? (
-            <Typography variant="body2" color="text.secondary" sx={{ p: 3 }}>
-              Loading mappings…
-            </Typography>
-          ) : mappings.length ? (
-            <Table size="small">
-              <TableHead>
-                <TableRow>
-                  <TableCell>Table</TableCell>
-                  <TableCell>Field</TableCell>
-                  <TableCell>Dimension</TableCell>
-                  <TableCell>Description</TableCell>
-                  <TableCell align="right">Actions</TableCell>
-                </TableRow>
-              </TableHead>
-              <TableBody>
-                {mappings.map((mapping) => (
-                  <TableRow key={mapping.id} hover>
-                    <TableCell>{mapping.source_table}</TableCell>
-                    <TableCell>{mapping.source_field}</TableCell>
-                    <TableCell>{mapping.ref_dimension}</TableCell>
-                    <TableCell>{mapping.description || '—'}</TableCell>
-                    <TableCell align="right">
-                      <IconButton onClick={() => openEdit(mapping)} aria-label="Edit mapping">
-                        <EditRoundedIcon fontSize="small" />
-                      </IconButton>
-                      <IconButton onClick={() => setDeleteTarget(mapping)} aria-label="Delete mapping">
-                        <DeleteRoundedIcon fontSize="small" />
-                      </IconButton>
-                    </TableCell>
-                  </TableRow>
+                <option value="">Select dimension</option>
+                {availableDimensions.map((dimension) => (
+                  <option key={dimension} value={dimension}>
+                    {dimension}
+                  </option>
                 ))}
-              </TableBody>
-            </Table>
-          ) : (
-            <Typography variant="body2" color="text.secondary" sx={{ p: 3 }}>
-              No mappings defined yet. Add one above to get started.
-            </Typography>
-          )}
-        </TableContainer>
-      </Paper>
-
-      <Paper variant="outlined" sx={{ p: { xs: 3, md: 4 } }}>
-        <Stack spacing={2}>
-          <Box>
-            <Typography variant="h6" fontWeight={600} gutterBottom>
-              Ingest sample values
-            </Typography>
-            <Typography variant="body2" color="text.secondary">
-              Paste raw values (optionally with counts) to simulate pulling data from the source. Each line accepts <code>value,count</code>.
-            </Typography>
-          </Box>
-          <Grid container spacing={2} columns={{ xs: 1, sm: 6, md: 12 }}>
-            <Grid item xs={1} sm={3} md={3}>
-              <TextField
-                label="Source table"
-                value={sampleTable}
-                onChange={(event) => setSampleTable(event.target.value)}
-                fullWidth
+              </Form.Select>
+            </Form.Group>
+            <Form.Group as={Col} md={12} controlId="mapping-description">
+              <Form.Label>Description</Form.Label>
+              <Form.Control
+                value={form.description ?? ''}
+                placeholder="Optional notes"
+                onChange={(event) => setForm((prev) => ({ ...prev, description: event.target.value }))}
               />
-            </Grid>
-            <Grid item xs={1} sm={3} md={3}>
-              <TextField
-                label="Source field"
-                value={sampleField}
-                onChange={(event) => setSampleField(event.target.value)}
-                fullWidth
-              />
-            </Grid>
-            <Grid item xs={1} sm={3} md={3}>
-              <FormControl fullWidth>
-                <InputLabel id="sample-dimension-label">Dimension (optional)</InputLabel>
-                <Select
-                  labelId="sample-dimension-label"
-                  label="Dimension (optional)"
-                  value={sampleDimension}
-                  onChange={(event) => setSampleDimension(event.target.value)}
-                >
-                  <MenuItem value="">Auto-detect</MenuItem>
-                  {availableDimensions.map((dimension) => (
-                    <MenuItem key={dimension} value={dimension}>
-                      {dimension}
-                    </MenuItem>
-                  ))}
-                </Select>
-              </FormControl>
-            </Grid>
-            <Grid item xs={1} sm={6} md={12}>
-              <TextField
-                label="Raw values"
-                value={sampleInput}
-                onChange={(event) => setSampleInput(event.target.value)}
-                fullWidth
-                multiline
-                minRows={4}
-                placeholder={`Single
-Married,12
-Divorced,3`}
-              />
-            </Grid>
-            <Grid item xs={1} sm={6} md={12}>
-              <Button
-                variant="contained"
-                startIcon={<UploadRoundedIcon />}
-                disabled={ingesting || !selectedConnectionId}
-                onClick={() => void handleIngest()}
-              >
-                {ingesting ? 'Ingesting…' : 'Ingest sample values'}
+            </Form.Group>
+            <Col xs={12} className="d-flex justify-content-end">
+              <Button type="submit" variant="primary" disabled={creating}>
+                {creating ? (
+                  <span className="d-inline-flex align-items-center gap-2">
+                    <Spinner animation="border" size="sm" role="status" aria-hidden="true" />
+                    Creating…
+                  </span>
+                ) : (
+                  'Add mapping'
+                )}
               </Button>
-            </Grid>
-          </Grid>
-        </Stack>
-      </Paper>
+            </Col>
+          </Form>
+        </Card.Body>
+      </Card>
 
-      <Dialog open={Boolean(editing)} onClose={() => setEditing(null)} maxWidth="sm" fullWidth>
-        <DialogTitle>Edit mapping</DialogTitle>
-        <DialogContent sx={{ pt: 2 }}>
-          <Stack spacing={2}>
-            <TextField
-              label="Source table"
-              value={editForm.source_table}
-              onChange={(event) => setEditForm((prev) => ({ ...prev, source_table: event.target.value }))}
-              fullWidth
-            />
-            <TextField
-              label="Source field"
-              value={editForm.source_field}
-              onChange={(event) => setEditForm((prev) => ({ ...prev, source_field: event.target.value }))}
-              fullWidth
-            />
-            <FormControl fullWidth>
-              <InputLabel id="edit-dimension-label">Reference dimension</InputLabel>
-              <Select
-                labelId="edit-dimension-label"
-                label="Reference dimension"
+      <Card className="card-section">
+        <Card.Body className="d-flex flex-column gap-3">
+          <div>
+            <Card.Title as="h2" className="section-heading h4 mb-1">
+              Existing mappings
+            </Card.Title>
+            <Card.Text className="text-body-secondary mb-0">
+              Manage mapped fields for the selected connection. Edit or remove entries as your schema evolves.
+            </Card.Text>
+          </div>
+          <div className="table-responsive">
+            <Table striped hover className="align-middle">
+              <thead>
+                <tr>
+                  <th>Source table</th>
+                  <th>Source field</th>
+                  <th>Dimension</th>
+                  <th>Description</th>
+                  <th className="text-end">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {loadingMappings && (
+                  <tr>
+                    <td colSpan={5} className="text-center py-4">
+                      Loading mappings…
+                    </td>
+                  </tr>
+                )}
+                {!loadingMappings && mappings.length === 0 && (
+                  <tr>
+                    <td colSpan={5} className="text-center text-body-secondary py-4">
+                      No mappings configured yet.
+                    </td>
+                  </tr>
+                )}
+                {!loadingMappings &&
+                  mappings.map((mapping) => (
+                    <tr key={mapping.id}>
+                      <td className="fw-semibold">{mapping.source_table}</td>
+                      <td>{mapping.source_field}</td>
+                      <td>{mapping.ref_dimension}</td>
+                      <td>{mapping.description || '—'}</td>
+                      <td className="text-end">
+                        <div className="d-inline-flex gap-2">
+                          <Button size="sm" variant="outline-primary" onClick={() => openEdit(mapping)}>
+                            Edit
+                          </Button>
+                          <Button size="sm" variant="outline-danger" onClick={() => setDeleteTarget(mapping)}>
+                            Delete
+                          </Button>
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+              </tbody>
+            </Table>
+          </div>
+        </Card.Body>
+      </Card>
+
+      <Card className="card-section">
+        <Card.Body className="d-flex flex-column gap-3">
+          <div>
+            <Card.Title as="h2" className="section-heading h4 mb-1">
+              Seed sample values
+            </Card.Title>
+            <Card.Text className="text-body-secondary mb-0">
+              Paste representative raw values to quickly generate match statistics. Provide counts as <code>value,count</code>.
+            </Card.Text>
+          </div>
+          <Form className="row g-3" onSubmit={(event) => event.preventDefault()}>
+            <Form.Group as={Col} md={4} controlId="sample-table">
+              <Form.Label>Source table</Form.Label>
+              <Form.Control value={sampleTable} onChange={(event) => setSampleTable(event.target.value)} required />
+            </Form.Group>
+            <Form.Group as={Col} md={4} controlId="sample-field">
+              <Form.Label>Source field</Form.Label>
+              <Form.Control value={sampleField} onChange={(event) => setSampleField(event.target.value)} required />
+            </Form.Group>
+            <Form.Group as={Col} md={4} controlId="sample-dimension">
+              <Form.Label>Dimension (optional)</Form.Label>
+              <Form.Control
+                value={sampleDimension}
+                placeholder="Override mapping dimension"
+                onChange={(event) => setSampleDimension(event.target.value)}
+              />
+            </Form.Group>
+            <Form.Group as={Col} md={12} controlId="sample-values">
+              <Form.Label>Values</Form.Label>
+              <Form.Control
+                as="textarea"
+                rows={6}
+                value={sampleInput}
+                placeholder={`Example:\nAbu Dhabi,12\nAl Ain,5`}
+                onChange={(event) => setSampleInput(event.target.value)}
+              />
+            </Form.Group>
+            <Col xs={12} className="d-flex justify-content-end">
+              <Button variant="success" onClick={() => void handleIngest()} disabled={ingesting}>
+                {ingesting ? (
+                  <span className="d-inline-flex align-items-center gap-2">
+                    <Spinner animation="border" size="sm" role="status" aria-hidden="true" />
+                    Uploading…
+                  </span>
+                ) : (
+                  'Ingest samples'
+                )}
+              </Button>
+            </Col>
+          </Form>
+        </Card.Body>
+      </Card>
+
+      <Modal show={Boolean(editing)} onHide={() => setEditing(null)} centered>
+        <Modal.Header closeButton>
+          <Modal.Title>Edit mapping</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <Form className="d-flex flex-column gap-3">
+            <Form.Group controlId="edit-source-table">
+              <Form.Label>Source table</Form.Label>
+              <Form.Control
+                value={editForm.source_table}
+                onChange={(event) => setEditForm((prev) => ({ ...prev, source_table: event.target.value }))}
+              />
+            </Form.Group>
+            <Form.Group controlId="edit-source-field">
+              <Form.Label>Source field</Form.Label>
+              <Form.Control
+                value={editForm.source_field}
+                onChange={(event) => setEditForm((prev) => ({ ...prev, source_field: event.target.value }))}
+              />
+            </Form.Group>
+            <Form.Group controlId="edit-dimension">
+              <Form.Label>Reference dimension</Form.Label>
+              <Form.Select
                 value={editForm.ref_dimension}
                 onChange={(event) => setEditForm((prev) => ({ ...prev, ref_dimension: event.target.value }))}
               >
                 {availableDimensions.map((dimension) => (
-                  <MenuItem key={dimension} value={dimension}>
+                  <option key={dimension} value={dimension}>
                     {dimension}
-                  </MenuItem>
+                  </option>
                 ))}
-              </Select>
-            </FormControl>
-            <TextField
-              label="Description"
-              value={editForm.description ?? ''}
-              onChange={(event) => setEditForm((prev) => ({ ...prev, description: event.target.value }))}
-              fullWidth
-            />
-          </Stack>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setEditing(null)}>Cancel</Button>
-          <Button onClick={() => void handleUpdate()} variant="contained" startIcon={<SaveRoundedIcon />}>
-            Save
+              </Form.Select>
+            </Form.Group>
+            <Form.Group controlId="edit-description">
+              <Form.Label>Description</Form.Label>
+              <Form.Control
+                value={editForm.description ?? ''}
+                onChange={(event) => setEditForm((prev) => ({ ...prev, description: event.target.value }))}
+              />
+            </Form.Group>
+          </Form>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button variant="outline-secondary" onClick={() => setEditing(null)}>
+            Cancel
           </Button>
-        </DialogActions>
-      </Dialog>
+          <Button variant="primary" onClick={() => void handleUpdate()} disabled={updating}>
+            {updating ? (
+              <span className="d-inline-flex align-items-center gap-2">
+                <Spinner animation="border" size="sm" role="status" aria-hidden="true" />
+                Saving…
+              </span>
+            ) : (
+              'Save changes'
+            )}
+          </Button>
+        </Modal.Footer>
+      </Modal>
 
-      <Dialog open={Boolean(deleteTarget)} onClose={() => setDeleteTarget(null)}>
-        <DialogTitle>Delete mapping</DialogTitle>
-        <DialogContent>
-          <Typography>
-            Remove the mapping for “{deleteTarget?.source_table}.{deleteTarget?.source_field}”?
-          </Typography>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setDeleteTarget(null)}>Cancel</Button>
-          <Button color="error" onClick={() => void handleDelete()} startIcon={<DeleteRoundedIcon />}>
-            Delete
+      <Modal show={Boolean(deleteTarget)} onHide={() => setDeleteTarget(null)} centered>
+        <Modal.Header closeButton>
+          <Modal.Title>Delete mapping</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          Delete mapping for <strong>{deleteTarget?.source_table}</strong> / <strong>{deleteTarget?.source_field}</strong>?
+        </Modal.Body>
+        <Modal.Footer>
+          <Button variant="outline-secondary" onClick={() => setDeleteTarget(null)}>
+            Cancel
           </Button>
-        </DialogActions>
-      </Dialog>
-    </Stack>
+          <Button variant="danger" onClick={() => void handleDelete()} disabled={deleting}>
+            {deleting ? (
+              <span className="d-inline-flex align-items-center gap-2">
+                <Spinner animation="border" size="sm" role="status" aria-hidden="true" />
+                Deleting…
+              </span>
+            ) : (
+              'Delete'
+            )}
+          </Button>
+        </Modal.Footer>
+      </Modal>
+    </div>
   );
 };
 

--- a/reviewer-ui/src/state/AppStateContext.tsx
+++ b/reviewer-ui/src/state/AppStateContext.tsx
@@ -65,7 +65,8 @@ export const AppStateProvider = ({ children }: PropsWithChildren) => {
     setIsLoading(false);
 
     if (errors.length) {
-      const message = `Unable to load ${errors.join(' & ')}`;
+      const joined = errors.length === 2 ? errors.join(' and ') : errors[0];
+      const message = `Unable to load ${joined} from the API. Confirm the backend service is running.`;
       setLoadError(message);
       return false;
     }

--- a/reviewer-ui/src/styles.css
+++ b/reviewer-ui/src/styles.css
@@ -2,125 +2,44 @@
   font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   line-height: 1.5;
   font-weight: 400;
-  color-scheme: light;
-  color: #111827;
-  background-color: #f8fafc;
 }
 
 body {
   margin: 0;
-  background-color: #f8fafc;
+  min-height: 100vh;
+  background-color: var(--bs-body-bg);
 }
 
-* {
-  box-sizing: border-box;
+.theme-dark {
+  background-image: radial-gradient(circle at 20% 20%, rgba(37, 99, 235, 0.08), transparent 55%),
+    radial-gradient(circle at 80% 0%, rgba(16, 185, 129, 0.08), transparent 50%);
 }
 
-a {
-  color: inherit;
+.theme-light {
+  background-image: radial-gradient(circle at 0% 0%, rgba(59, 130, 246, 0.06), transparent 45%),
+    radial-gradient(circle at 100% 50%, rgba(251, 191, 36, 0.05), transparent 40%);
 }
 
-.app-wrapper {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 2rem;
+.theme-midnight {
+  background-color: #020617;
+  background-image: radial-gradient(circle at 15% 25%, rgba(96, 165, 250, 0.12), transparent 55%),
+    radial-gradient(circle at 85% 10%, rgba(129, 140, 248, 0.1), transparent 45%);
 }
 
-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 2rem;
+.card-section {
+  border-radius: 1rem;
+  box-shadow: 0 1.25rem 2.5rem -2rem rgba(15, 23, 42, 0.65);
 }
 
-h1 {
-  font-size: 2rem;
-  margin: 0;
-}
-
-section {
-  background: #ffffff;
-  border-radius: 12px;
-  padding: 1.5rem;
-  box-shadow: 0 10px 30px -20px rgba(15, 23, 42, 0.4);
-  margin-bottom: 1.5rem;
-}
-
-section h2 {
-  margin-top: 0;
-  font-size: 1.25rem;
-}
-
-form {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-}
-
-input,
-select,
-textarea,
-button {
-  padding: 0.6rem 0.75rem;
-  border-radius: 8px;
-  border: 1px solid #d1d5db;
-  font-size: 1rem;
-}
-
-button {
-  background-color: #2563eb;
-  color: #ffffff;
-  border: none;
-  cursor: pointer;
+.section-heading {
   font-weight: 600;
-  transition: background-color 0.2s ease;
 }
 
-button:hover {
-  background-color: #1d4ed8;
+.text-monospaced {
+  font-family: 'IBM Plex Mono', 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
 }
 
-button:disabled {
-  background-color: #93c5fd;
-  cursor: not-allowed;
-}
-
-.table {
-  width: 100%;
-  border-collapse: collapse;
-  margin-top: 1rem;
-}
-
-.table th,
-.table td {
-  border: 1px solid #e2e8f0;
-  padding: 0.75rem;
-  text-align: left;
-}
-
-.badge {
-  display: inline-block;
-  padding: 0.2rem 0.5rem;
-  border-radius: 999px;
-  background: #e0e7ff;
-  color: #3730a3;
-  font-size: 0.75rem;
-}
-
-.alert {
-  border-radius: 8px;
-  padding: 0.75rem 1rem;
-  background: #fef3c7;
-  color: #92400e;
-}
-
-.grid {
-  display: grid;
-  gap: 1rem;
-}
-
-@media (min-width: 768px) {
-  .grid.two-columns {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
+.table-nowrap td,
+.table-nowrap th {
+  white-space: nowrap;
 }

--- a/reviewer-ui/src/themes.ts
+++ b/reviewer-ui/src/themes.ts
@@ -1,100 +1,42 @@
-import { PaletteMode, ThemeOptions } from '@mui/material';
-
-export type ThemeChoice = 'dark' | 'warm' | 'cool' | 'lively';
+export type ThemeChoice = 'dark' | 'light' | 'midnight';
 
 interface ThemeDefinition {
   label: string;
-  paletteMode: PaletteMode;
-  options: ThemeOptions;
+  dataTheme: 'dark' | 'light';
+  bodyClass?: string;
 }
 
 export const themeDefinitions: Record<ThemeChoice, ThemeDefinition> = {
   dark: {
     label: 'Dark',
-    paletteMode: 'dark',
-    options: {
-      palette: {
-        mode: 'dark',
-        primary: { main: '#90caf9' },
-        secondary: { main: '#f48fb1' },
-        background: {
-          default: '#0f172a',
-          paper: '#111c34',
-        },
-      },
-      shape: { borderRadius: 12 },
-      typography: {
-        fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif',
-      },
-    },
+    dataTheme: 'dark',
+    bodyClass: 'theme-dark',
   },
-  warm: {
-    label: 'Warm',
-    paletteMode: 'light',
-    options: {
-      palette: {
-        mode: 'light',
-        primary: { main: '#b23a48' },
-        secondary: { main: '#f59f80' },
-        background: {
-          default: '#fff7ed',
-          paper: '#fff1e6',
-        },
-        text: {
-          primary: '#432818',
-          secondary: '#7f5539',
-        },
-      },
-      shape: { borderRadius: 14 },
-      typography: {
-        fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif',
-      },
-    },
+  light: {
+    label: 'Light',
+    dataTheme: 'light',
+    bodyClass: 'theme-light',
   },
-  cool: {
-    label: 'Cool',
-    paletteMode: 'light',
-    options: {
-      palette: {
-        mode: 'light',
-        primary: { main: '#1b4b8c' },
-        secondary: { main: '#58a6ff' },
-        background: {
-          default: '#eef4ff',
-          paper: '#f7faff',
-        },
-        text: {
-          primary: '#0b1a33',
-          secondary: '#3f4c67',
-        },
-      },
-      shape: { borderRadius: 14 },
-      typography: {
-        fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif',
-      },
-    },
-  },
-  lively: {
-    label: 'Lively',
-    paletteMode: 'light',
-    options: {
-      palette: {
-        mode: 'light',
-        primary: { main: '#7c3aed' },
-        secondary: { main: '#f97316' },
-        background: {
-          default: '#fdf4ff',
-          paper: '#ffffff',
-        },
-        success: { main: '#16a34a' },
-        warning: { main: '#facc15' },
-      },
-      shape: { borderRadius: 16 },
-      typography: {
-        fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif',
-      },
-    },
+  midnight: {
+    label: 'Midnight',
+    dataTheme: 'dark',
+    bodyClass: 'theme-midnight',
   },
 };
 
-export const themeOrder: ThemeChoice[] = ['dark', 'warm', 'cool', 'lively'];
+export const themeOrder: ThemeChoice[] = ['dark', 'light', 'midnight'];
+
+export function applyTheme(choice: ThemeChoice): void {
+  const definition = themeDefinitions[choice];
+  document.body.dataset.bsTheme = definition.dataTheme;
+
+  document.body.classList.remove(
+    ...Object.values(themeDefinitions)
+      .map((theme) => theme.bodyClass)
+      .filter((value): value is string => Boolean(value)),
+  );
+
+  if (definition.bodyClass) {
+    document.body.classList.add(definition.bodyClass);
+  }
+}


### PR DESCRIPTION
## Summary
- replace the reviewer UI Material UI implementation with a Bootstrap 5 layout and styling utilities
- add a dedicated canonical library page with filtering, bulk import, CSV export, and Abu Dhabi dataset documentation
- refactor feature pages (connections, field mappings, match insights, suggestions, mapping history) to match the new design system and improve error messaging

## Testing
- pytest
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dbd0179dd88332925934dd5838c8f7