### PR TITLE
Add dimension management, relations, and smarter bulk import

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ The interface is organised into task-focused pages that surface the entire curat
   switching and mobile-friendly navigation.
 - **Dashboard** – configure matcher parameters and experiment with semantic suggestions in a live playground.
 - **Canonical Library** – manage curated reference values, filter by dimension, import tabular data in bulk, and export the library to CSV.
+- **Dimensions** – maintain each dimension's code, label, description, and custom attribute schema.
+- **Dimension Relations** – model parent/child hierarchies such as regions to districts and manage canonical value pairings.
 - **Source Connections** – register and maintain connectivity metadata for upstream systems.
 - **Field Mappings** – align source tables/fields to reference dimensions and ingest sample values for reconciliation analytics.
 - **Match Insights** – visualise match rates per mapping, inspect top outliers, and track overall harmonisation health.
@@ -48,6 +50,9 @@ OpenMetadata-inspired experience and design principles.
 The FastAPI service now exposes a rich set of endpoints under `/api`:
 
 - `/reference/canonical` – full CRUD for canonical reference values.
+- `/reference/canonical/import` – parse CSV/TSV/Excel uploads and create canonical values in bulk.
+- `/reference/dimensions` – manage the dimension catalog and attribute schema.
+- `/reference/dimension-relations` – define parent/child relationships and retrieve linked canonical pairs.
 - `/source/connections` – manage source system connection metadata.
 - `/source/connections/{id}/mappings` – create/update/delete field mappings to reference dimensions.
 - `/source/connections/{id}/samples` – ingest aggregated raw samples collected from source systems or manual uploads.
@@ -92,11 +97,11 @@ npm run build
 npm test
 ```
 
-The build step runs TypeScript in strict mode alongside the Vite production bundle to
-catch typing regressions in mocked React components. The dedicated `createProps`
-helper inside `src/App.test.tsx` wraps Vitest mocks with real callbacks so TypeScript
-accepts them as valid `AppScaffold` props while still exposing rich assertion helpers
-for the tests.
+The build step runs TypeScript in strict mode alongside the Vite production bundle to catch typing regressions in mocked React
+components. The dedicated `createProps` helper inside `src/App.test.tsx` wraps Vitest mocks with real callbacks so TypeScript
+accepts them as valid `AppScaffold` props while still exposing rich assertion helpers for the tests. The navigation suite now
+covers the new dimension governance and relation workspaces, ensuring the shared toast and routing scaffolding continue to
+operate as the UI grows.
 
 The new Reviewer UI deployment checks verify that the custom Nginx configuration is copied into the container image and that it
 rewrites unknown application routes back to `index.html`. This prevents regressions where client-side routes return HTTP 404s

--- a/api/app/routes/reference.py
+++ b/api/app/routes/reference.py
@@ -2,32 +2,194 @@
 
 from __future__ import annotations
 
+import io
 import logging
+import re
+from pathlib import Path
+from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException, Response, status
+import pandas as pd
+from fastapi import (
+    APIRouter,
+    Depends,
+    File,
+    Form,
+    HTTPException,
+    Response,
+    UploadFile,
+    status,
+)
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import aliased
+from sqlalchemy.sql import func
 from sqlmodel import Session, select
 
 from ..database import get_session
 from ..matcher import SemanticMatcher
-from ..models import CanonicalValue, RawValue, SystemConfig
+from ..models import (
+    CanonicalValue,
+    Dimension,
+    DimensionRelation,
+    DimensionRelationLink,
+    RawValue,
+    SystemConfig,
+)
 from ..schemas import (
+    BulkImportResult,
     CanonicalValueCreate,
     CanonicalValueRead,
     CanonicalValueUpdate,
+    DimensionCreate,
+    DimensionRead,
+    DimensionRelationCreate,
+    DimensionRelationLinkCreate,
+    DimensionRelationLinkRead,
+    DimensionRelationRead,
+    DimensionRelationUpdate,
+    DimensionUpdate,
     MatchRequest,
     MatchResponse,
+)
+from ..services.dimensions import (
+    dimension_to_read_model,
+    ensure_dimension_can_be_removed,
+    relation_to_read_model,
+    remove_links_for_canonical,
+    require_dimension,
+    validate_attributes,
+    validate_extra_fields,
 )
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/reference", tags=["reference"])
 
+DIMENSION_COLUMN_KEYS = {
+    "dimension",
+    "dimension_code",
+    "dimensionid",
+    "dim",
+    "domain",
+    "category",
+}
+LABEL_COLUMN_KEYS = {
+    "canonical_label",
+    "label",
+    "name",
+    "value",
+    "canonical",
+    "canonicalvalue",
+}
+DESCRIPTION_COLUMN_KEYS = {
+    "description",
+    "detail",
+    "details",
+    "notes",
+    "note",
+    "summary",
+    "comment",
+}
+
+
+def _normalise(text: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "_", text.strip().lower()).strip("_")
+
+
+def _load_dataframe(buffer: bytes, filename: str | None) -> pd.DataFrame:
+    if not buffer:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Uploaded file is empty.",
+        )
+
+    extension = (Path(filename or "").suffix or "").lower()
+    stream = io.BytesIO(buffer)
+
+    if extension in {".xls", ".xlsx"}:
+        try:
+            df = pd.read_excel(stream)
+        except ValueError as exc:  # pragma: no cover - defensive guard
+            logger.exception("Failed to parse Excel payload", exc_info=exc)
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Unable to parse Excel file. Ensure the sheet includes a header row.",
+            ) from exc
+    else:
+        df = None
+        for separator in [None, ",", ";", "\t", "|"]:
+            stream.seek(0)
+            try:
+                candidate = pd.read_csv(stream, sep=separator, engine="python")
+            except Exception:  # pragma: no cover - pandas raises numerous subclasses
+                continue
+            if not candidate.empty:
+                df = candidate
+                break
+        if df is None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    "Unable to parse uploaded file. Provide a CSV or Excel sheet "
+                    "with a header row describing each column."
+                ),
+            )
+
+    df = df.dropna(how="all")
+    df = df.dropna(axis=1, how="all")
+    if df.empty:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Uploaded table does not contain any data rows.",
+        )
+
+    df.columns = [str(column) for column in df.columns]
+    return df
+
+
+def _identify_columns(columns: list[str]) -> dict[str, str | None]:
+    normalised_map = {_normalise(column): column for column in columns}
+    dimension_column = next(
+        (normalised_map[key] for key in DIMENSION_COLUMN_KEYS if key in normalised_map),
+        None,
+    )
+    label_column = next(
+        (normalised_map[key] for key in LABEL_COLUMN_KEYS if key in normalised_map),
+        None,
+    )
+    description_column = next(
+        (
+            normalised_map[key]
+            for key in DESCRIPTION_COLUMN_KEYS
+            if key in normalised_map
+        ),
+        None,
+    )
+    return {
+        "dimension": dimension_column,
+        "label": label_column,
+        "description": description_column,
+    }
+
+
+def _safe_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    try:
+        if pd.isna(value):
+            return None
+    except TypeError:
+        pass
+    text = str(value).strip()
+    return text or None
+
 
 @router.get("/canonical", response_model=list[CanonicalValueRead])
 def list_canonical_values(session: Session = Depends(get_session)) -> list[CanonicalValue]:
     """Return all canonical values ordered by dimension and label."""
 
-    statement = select(CanonicalValue).order_by(CanonicalValue.dimension, CanonicalValue.canonical_label)
+    statement = select(CanonicalValue).order_by(
+        CanonicalValue.dimension, CanonicalValue.canonical_label
+    )
     results = session.exec(statement).all()
     logger.debug("Canonical values requested", extra={"count": len(results)})
     return results
@@ -43,7 +205,15 @@ def create_canonical_value(
 ) -> CanonicalValue:
     """Create and persist a canonical value."""
 
-    canonical = CanonicalValue(**payload.model_dump())
+    dimension = require_dimension(session, payload.dimension)
+    attributes = validate_attributes(dimension, payload.attributes)
+
+    canonical = CanonicalValue(
+        dimension=dimension.code,
+        canonical_label=payload.canonical_label,
+        description=payload.description,
+        attributes=attributes,
+    )
     session.add(canonical)
     session.commit()
     session.refresh(canonical)
@@ -60,11 +230,24 @@ def update_canonical_value(
 
     canonical = session.get(CanonicalValue, canonical_id)
     if not canonical:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Canonical value not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Canonical value not found"
+        )
 
-    data = payload.model_dump(exclude_unset=True)
+    target_dimension_code = payload.dimension or canonical.dimension
+    dimension = require_dimension(session, target_dimension_code)
+
+    if payload.attributes is not None:
+        attributes = validate_attributes(dimension, payload.attributes)
+    else:
+        attributes = validate_attributes(dimension, canonical.attributes)
+
+    data = payload.model_dump(exclude_unset=True, exclude={"attributes"})
     for key, value in data.items():
         setattr(canonical, key, value)
+
+    canonical.attributes = attributes
+    canonical.dimension = dimension.code
 
     session.add(canonical)
     session.commit()
@@ -80,8 +263,11 @@ def delete_canonical_value(
 
     canonical = session.get(CanonicalValue, canonical_id)
     if not canonical:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Canonical value not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Canonical value not found"
+        )
 
+    remove_links_for_canonical(session, canonical_id)
     session.delete(canonical)
     session.commit()
     return Response(status_code=status.HTTP_204_NO_CONTENT)
@@ -97,23 +283,32 @@ def propose_match(
     if not config:
         raise HTTPException(status_code=500, detail="System configuration missing")
 
-    dimension = payload.dimension or config.default_dimension
+    if payload.dimension:
+        dimension = require_dimension(session, payload.dimension)
+    else:
+        dimension = require_dimension(session, config.default_dimension)
+
+    dimension_code = dimension.code
 
     canonical_values = session.exec(
-        select(CanonicalValue).where(CanonicalValue.dimension == dimension)
+        select(CanonicalValue).where(CanonicalValue.dimension == dimension_code)
     ).all()
 
-    if not canonical_values:
+    if not canonical_values and dimension_code != config.default_dimension:
+        fallback_dimension = require_dimension(session, config.default_dimension)
         canonical_values = session.exec(
-            select(CanonicalValue).where(CanonicalValue.dimension == config.default_dimension)
+            select(CanonicalValue).where(
+                CanonicalValue.dimension == fallback_dimension.code
+            )
         ).all()
+        dimension_code = fallback_dimension.code
 
     matcher = SemanticMatcher(config=config, canonical_values=canonical_values)
     ranked = matcher.rank(payload.raw_text)
     filtered = [match for match in ranked if match.score >= config.match_threshold]
 
     raw = RawValue(
-        dimension=dimension,
+        dimension=dimension_code,
         raw_text=payload.raw_text,
         status="suggested" if filtered else "pending",
         proposed_canonical_id=filtered[0].canonical_id if filtered else None,
@@ -122,4 +317,452 @@ def propose_match(
     session.commit()
     session.refresh(raw)
 
-    return MatchResponse(raw_text=payload.raw_text, dimension=dimension, matches=filtered)
+    return MatchResponse(
+        raw_text=payload.raw_text, dimension=dimension_code, matches=filtered
+    )
+
+
+@router.get("/dimensions", response_model=list[DimensionRead])
+def list_dimensions(session: Session = Depends(get_session)) -> list[DimensionRead]:
+    dimensions = session.exec(select(Dimension).order_by(Dimension.label)).all()
+    logger.debug("Dimensions requested", extra={"count": len(dimensions)})
+    return [dimension_to_read_model(dimension) for dimension in dimensions]
+
+
+@router.post("/dimensions", response_model=DimensionRead, status_code=status.HTTP_201_CREATED)
+def create_dimension(
+    payload: DimensionCreate, session: Session = Depends(get_session)
+) -> DimensionRead:
+    extra_schema = validate_extra_fields(payload.extra_fields)
+    dimension = Dimension(
+        code=payload.code,
+        label=payload.label,
+        description=payload.description,
+        extra_schema=extra_schema,
+    )
+
+    session.add(dimension)
+    try:
+        session.commit()
+    except IntegrityError as exc:
+        session.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Dimension '{payload.code}' already exists.",
+        ) from exc
+
+    session.refresh(dimension)
+    return dimension_to_read_model(dimension)
+
+
+@router.put("/dimensions/{code}", response_model=DimensionRead)
+def update_dimension(
+    code: str, payload: DimensionUpdate, session: Session = Depends(get_session)
+) -> DimensionRead:
+    dimension = require_dimension(session, code)
+    data = payload.model_dump(exclude_unset=True)
+
+    if "extra_fields" in data:
+        dimension.extra_schema = validate_extra_fields(data.pop("extra_fields"))
+
+    for key, value in data.items():
+        setattr(dimension, key, value)
+
+    dimension.touch()
+    session.add(dimension)
+    session.commit()
+    session.refresh(dimension)
+    return dimension_to_read_model(dimension)
+
+
+@router.delete("/dimensions/{code}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_dimension(code: str, session: Session = Depends(get_session)) -> Response:
+    dimension = require_dimension(session, code)
+    ensure_dimension_can_be_removed(session, code)
+    session.delete(dimension)
+    session.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.get(
+    "/dimension-relations",
+    response_model=list[DimensionRelationRead],
+)
+def list_dimension_relations(
+    session: Session = Depends(get_session),
+) -> list[DimensionRelationRead]:
+    relations = session.exec(select(DimensionRelation)).all()
+    dimensions = session.exec(select(Dimension)).all()
+    dimension_map = {dimension.code: dimension for dimension in dimensions}
+
+    payloads: list[DimensionRelationRead] = []
+    for relation in relations:
+        parent = dimension_map.get(relation.parent_dimension_code)
+        child = dimension_map.get(relation.child_dimension_code)
+        if not parent or not child:
+            logger.warning(
+                "Dimension relation has orphaned references",
+                extra={"relation_id": relation.id},
+            )
+            continue
+        link_count = session.exec(
+            select(func.count()).where(
+                DimensionRelationLink.relation_id == relation.id
+            )
+        ).one()[0]
+        payloads.append(
+            relation_to_read_model(relation, parent=parent, child=child, link_count=link_count)
+        )
+
+    logger.debug(
+        "Dimension relations requested", extra={"count": len(payloads)}
+    )
+    return payloads
+
+
+@router.post(
+    "/dimension-relations",
+    response_model=DimensionRelationRead,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_dimension_relation(
+    payload: DimensionRelationCreate, session: Session = Depends(get_session)
+) -> DimensionRelationRead:
+    parent = require_dimension(session, payload.parent_dimension_code)
+    child = require_dimension(session, payload.child_dimension_code)
+
+    if parent.code == child.code:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Parent and child dimensions must be different.",
+        )
+
+    relation = DimensionRelation(
+        label=payload.label,
+        parent_dimension_code=parent.code,
+        child_dimension_code=child.code,
+        description=payload.description,
+    )
+    session.add(relation)
+    try:
+        session.commit()
+    except IntegrityError as exc:
+        session.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="A relation with the same label already exists for these dimensions.",
+        ) from exc
+
+    session.refresh(relation)
+    return relation_to_read_model(relation, parent=parent, child=child, link_count=0)
+
+
+@router.put(
+    "/dimension-relations/{relation_id}",
+    response_model=DimensionRelationRead,
+)
+def update_dimension_relation(
+    relation_id: int,
+    payload: DimensionRelationUpdate,
+    session: Session = Depends(get_session),
+) -> DimensionRelationRead:
+    relation = session.get(DimensionRelation, relation_id)
+    if not relation:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Dimension relation not found"
+        )
+
+    data = payload.model_dump(exclude_unset=True)
+    for key, value in data.items():
+        setattr(relation, key, value)
+    relation.touch()
+    session.add(relation)
+    session.commit()
+    session.refresh(relation)
+
+    parent = require_dimension(session, relation.parent_dimension_code)
+    child = require_dimension(session, relation.child_dimension_code)
+    link_count = session.exec(
+        select(func.count()).where(DimensionRelationLink.relation_id == relation.id)
+    ).one()[0]
+
+    return relation_to_read_model(relation, parent=parent, child=child, link_count=link_count)
+
+
+@router.delete(
+    "/dimension-relations/{relation_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+def delete_dimension_relation(
+    relation_id: int, session: Session = Depends(get_session)
+) -> Response:
+    relation = session.get(DimensionRelation, relation_id)
+    if not relation:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Dimension relation not found"
+        )
+
+    links = session.exec(
+        select(DimensionRelationLink).where(DimensionRelationLink.relation_id == relation_id)
+    ).all()
+    for link in links:
+        session.delete(link)
+
+    session.delete(relation)
+    session.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.get(
+    "/dimension-relations/{relation_id}/links",
+    response_model=list[DimensionRelationLinkRead],
+)
+def list_dimension_relation_links(
+    relation_id: int, session: Session = Depends(get_session)
+) -> list[DimensionRelationLinkRead]:
+    relation = session.get(DimensionRelation, relation_id)
+    if not relation:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Dimension relation not found"
+        )
+
+    parent_alias = aliased(CanonicalValue)
+    child_alias = aliased(CanonicalValue)
+    statement = (
+        select(
+            DimensionRelationLink,
+            parent_alias.canonical_label,
+            child_alias.canonical_label,
+        )
+        .join(parent_alias, parent_alias.id == DimensionRelationLink.parent_canonical_id)
+        .join(child_alias, child_alias.id == DimensionRelationLink.child_canonical_id)
+        .where(DimensionRelationLink.relation_id == relation_id)
+        .order_by(parent_alias.canonical_label, child_alias.canonical_label)
+    )
+
+    results = session.exec(statement).all()
+    payloads = [
+        DimensionRelationLinkRead(
+            id=link.id,
+            relation_id=link.relation_id,
+            parent_canonical_id=link.parent_canonical_id,
+            child_canonical_id=link.child_canonical_id,
+            parent_label=parent_label,
+            child_label=child_label,
+            created_at=link.created_at,
+            updated_at=link.updated_at,
+        )
+        for link, parent_label, child_label in results
+    ]
+
+    logger.debug(
+        "Dimension relation links requested",
+        extra={"relation_id": relation_id, "count": len(payloads)},
+    )
+    return payloads
+
+
+@router.post(
+    "/dimension-relations/{relation_id}/links",
+    response_model=DimensionRelationLinkRead,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_dimension_relation_link(
+    relation_id: int,
+    payload: DimensionRelationLinkCreate,
+    session: Session = Depends(get_session),
+) -> DimensionRelationLinkRead:
+    relation = session.get(DimensionRelation, relation_id)
+    if not relation:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Dimension relation not found"
+        )
+
+    parent = session.get(CanonicalValue, payload.parent_canonical_id)
+    child = session.get(CanonicalValue, payload.child_canonical_id)
+    if not parent or not child:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid canonical identifiers supplied.",
+        )
+
+    if parent.dimension != relation.parent_dimension_code:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Parent canonical value does not belong to the parent dimension.",
+        )
+
+    if child.dimension != relation.child_dimension_code:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Child canonical value does not belong to the child dimension.",
+        )
+
+    existing = session.exec(
+        select(DimensionRelationLink)
+        .where(DimensionRelationLink.relation_id == relation_id)
+        .where(DimensionRelationLink.parent_canonical_id == payload.parent_canonical_id)
+        .where(DimensionRelationLink.child_canonical_id == payload.child_canonical_id)
+    ).first()
+    if existing:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="This link already exists for the selected relation.",
+        )
+
+    link = DimensionRelationLink(
+        relation_id=relation_id,
+        parent_canonical_id=payload.parent_canonical_id,
+        child_canonical_id=payload.child_canonical_id,
+    )
+    session.add(link)
+    session.commit()
+    session.refresh(link)
+
+    return DimensionRelationLinkRead(
+        id=link.id,
+        relation_id=link.relation_id,
+        parent_canonical_id=link.parent_canonical_id,
+        child_canonical_id=link.child_canonical_id,
+        parent_label=parent.canonical_label,
+        child_label=child.canonical_label,
+        created_at=link.created_at,
+        updated_at=link.updated_at,
+    )
+
+
+@router.delete(
+    "/dimension-relations/{relation_id}/links/{link_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+def delete_dimension_relation_link(
+    relation_id: int,
+    link_id: int,
+    session: Session = Depends(get_session),
+) -> Response:
+    link = session.get(DimensionRelationLink, link_id)
+    if not link or link.relation_id != relation_id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Relation link not found"
+        )
+
+    session.delete(link)
+    session.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.post(
+    "/canonical/import",
+    response_model=BulkImportResult,
+    status_code=status.HTTP_201_CREATED,
+)
+async def import_canonical_values(
+    session: Session = Depends(get_session),
+    dimension: str | None = Form(default=None),
+    file: UploadFile | None = File(default=None),
+    inline_text: str | None = Form(default=None),
+) -> BulkImportResult:
+    if not file and not inline_text:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Provide a CSV/Excel file or paste tabular text to import.",
+        )
+
+    filename = file.filename if file else "pasted.csv"
+    if file:
+        payload_bytes = await file.read()
+    else:
+        payload_bytes = inline_text.encode("utf-8")
+
+    dataframe = _load_dataframe(payload_bytes, filename)
+    column_map = _identify_columns(list(dataframe.columns))
+    label_column = column_map.get("label")
+    if not label_column:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                "Unable to identify the canonical label column. Add a header such as "
+                "'label' or 'canonical_label'."
+            ),
+        )
+
+    dimension_column = column_map.get("dimension")
+    description_column = column_map.get("description")
+    optional_columns = {
+        column
+        for column in dataframe.columns
+        if column not in {dimension_column, label_column, description_column}
+    }
+
+    created: list[CanonicalValueRead] = []
+    errors: list[str] = []
+    dimension_cache: dict[str, Dimension] = {}
+
+    def get_dimension(code: str) -> Dimension | None:
+        if code not in dimension_cache:
+            try:
+                dimension_cache[code] = require_dimension(session, code)
+            except HTTPException:
+                dimension_cache[code] = None  # type: ignore[assignment]
+        return dimension_cache.get(code)
+
+    for row_number, row in enumerate(
+        dataframe.to_dict(orient="records"), start=2
+    ):
+        label_value = _safe_str(row.get(label_column))
+        if not label_value:
+            errors.append(f"Row {row_number}: Missing canonical label; skipping entry.")
+            continue
+
+        if dimension_column:
+            dimension_value = _safe_str(row.get(dimension_column)) or dimension
+        else:
+            dimension_value = dimension
+
+        if not dimension_value:
+            errors.append(
+                f"Row {row_number}: Missing dimension and no default provided; skipping entry."
+            )
+            continue
+
+        dimension_model = get_dimension(dimension_value)
+        if not dimension_model:
+            errors.append(
+                f"Row {row_number}: Dimension '{dimension_value}' does not exist."
+            )
+            continue
+
+        description_value = _safe_str(row.get(description_column)) if description_column else None
+        attribute_payload = {column: row.get(column) for column in optional_columns}
+
+        try:
+            attributes = validate_attributes(dimension_model, attribute_payload)
+        except HTTPException as exc:
+            errors.append(f"Row {row_number}: {exc.detail}")
+            continue
+
+        canonical = CanonicalValue(
+            dimension=dimension_model.code,
+            canonical_label=label_value,
+            description=description_value,
+            attributes=attributes,
+        )
+
+        session.add(canonical)
+        try:
+            session.commit()
+        except IntegrityError as exc:  # pragma: no cover - depends on DB constraints
+            session.rollback()
+            errors.append(
+                f"Row {row_number}: Unable to persist canonical value ({exc.orig})."
+            )
+            continue
+
+        session.refresh(canonical)
+        created.append(CanonicalValueRead.model_validate(canonical))
+
+    logger.info(
+        "Bulk canonical import processed",
+        extra={"created": len(created), "errors": len(errors)},
+    )
+    return BulkImportResult(created=created, errors=errors)

--- a/api/app/seeds.py
+++ b/api/app/seeds.py
@@ -3,24 +3,95 @@
 from __future__ import annotations
 
 import logging
-from typing import Sequence
+from typing import Any, Sequence
 
 from sqlmodel import Session, select
 
 from .config import Settings, load_settings
-from .models import CanonicalValue
+from .models import CanonicalValue, Dimension
 from .services.config import ensure_system_config
 
 logger = logging.getLogger(__name__)
 
 
-DEFAULT_CANONICAL_VALUES: Sequence[dict[str, str]] = (
-    {"dimension": "marital_status", "canonical_label": "Single", "description": "Not married"},
-    {"dimension": "marital_status", "canonical_label": "Married", "description": "Married or civil partnership"},
-    {"dimension": "education", "canonical_label": "High School", "description": "Completed secondary education"},
-    {"dimension": "education", "canonical_label": "Bachelor's Degree", "description": "Undergraduate degree"},
-    {"dimension": "employment_status", "canonical_label": "Employed", "description": "Currently employed"},
-    {"dimension": "employment_status", "canonical_label": "Unemployed", "description": "Not presently employed"},
+DEFAULT_DIMENSIONS: Sequence[dict[str, Any]] = (
+    {
+        "code": "general",
+        "label": "General",
+        "description": "Fallback dimension used when no specific taxonomy is selected.",
+        "extra_schema": [],
+    },
+    {
+        "code": "marital_status",
+        "label": "Marital status",
+        "description": "Standardised marital state descriptors.",
+        "extra_schema": [
+            {
+                "key": "code",
+                "label": "Code",
+                "description": "Short code used by legacy systems.",
+                "data_type": "string",
+                "required": False,
+            }
+        ],
+    },
+    {
+        "code": "education",
+        "label": "Education level",
+        "description": "Highest attained education for an individual.",
+        "extra_schema": [
+            {
+                "key": "unesco_level",
+                "label": "UNESCO Level",
+                "description": "International education classification code.",
+                "data_type": "string",
+                "required": False,
+            }
+        ],
+    },
+    {
+        "code": "employment_status",
+        "label": "Employment status",
+        "description": "Employment standing as reported by HR or census sources.",
+        "extra_schema": [],
+    },
+)
+
+DEFAULT_CANONICAL_VALUES: Sequence[dict[str, Any]] = (
+    {
+        "dimension": "marital_status",
+        "canonical_label": "Single",
+        "description": "Not married",
+        "attributes": {"code": "S"},
+    },
+    {
+        "dimension": "marital_status",
+        "canonical_label": "Married",
+        "description": "Married or civil partnership",
+        "attributes": {"code": "M"},
+    },
+    {
+        "dimension": "education",
+        "canonical_label": "High School",
+        "description": "Completed secondary education",
+        "attributes": {"unesco_level": "2"},
+    },
+    {
+        "dimension": "education",
+        "canonical_label": "Bachelor's Degree",
+        "description": "Undergraduate degree",
+        "attributes": {"unesco_level": "6"},
+    },
+    {
+        "dimension": "employment_status",
+        "canonical_label": "Employed",
+        "description": "Currently employed",
+    },
+    {
+        "dimension": "employment_status",
+        "canonical_label": "Unemployed",
+        "description": "Not presently employed",
+    },
 )
 
 
@@ -31,13 +102,31 @@ def seed_database(engine, settings: Settings | None = None) -> None:
     with Session(engine) as session:
         ensure_system_config(session, settings=settings)
 
-        existing = session.exec(select(CanonicalValue)).all()
-        if not existing:
-            logger.info("Seeding default canonical values", extra={"count": len(DEFAULT_CANONICAL_VALUES)})
+        existing_dimensions = session.exec(select(Dimension)).all()
+        if not existing_dimensions:
+            logger.info(
+                "Seeding default dimensions", extra={"count": len(DEFAULT_DIMENSIONS)}
+            )
+            for payload in DEFAULT_DIMENSIONS:
+                session.add(Dimension(**payload))
+            session.commit()
+        else:
+            logger.debug(
+                "Dimensions already present", extra={"count": len(existing_dimensions)}
+            )
+
+        existing_canonical = session.exec(select(CanonicalValue)).all()
+        if not existing_canonical:
+            logger.info(
+                "Seeding default canonical values",
+                extra={"count": len(DEFAULT_CANONICAL_VALUES)},
+            )
             for payload in DEFAULT_CANONICAL_VALUES:
                 session.add(CanonicalValue(**payload))
+            session.commit()
         else:
-            logger.debug("Canonical library already seeded", extra={"count": len(existing)})
+            logger.debug(
+                "Canonical library already seeded", extra={"count": len(existing_canonical)}
+            )
 
-        session.commit()
         logger.debug("Database seed process complete")

--- a/api/app/services/dimensions.py
+++ b/api/app/services/dimensions.py
@@ -1,0 +1,255 @@
+"""Utilities for managing dimension schemas and validations."""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, Iterable
+
+from fastapi import HTTPException, status
+from sqlmodel import Session, select
+
+from ..models import CanonicalValue, Dimension, DimensionRelation, DimensionRelationLink
+from ..schemas import (
+    DimensionExtraFieldDefinition,
+    DimensionRead,
+    DimensionRelationRead,
+)
+
+logger = logging.getLogger(__name__)
+
+SUPPORTED_FIELD_TYPES = {"string", "number", "boolean"}
+
+
+def _normalise_key(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "_", value.strip().lower()).strip("_")
+
+
+def validate_extra_fields(
+    definitions: Iterable[DimensionExtraFieldDefinition | dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Ensure the dimension extra field schema is well-defined."""
+
+    normalised_keys: set[str] = set()
+    validated: list[dict[str, Any]] = []
+
+    coerced: list[DimensionExtraFieldDefinition] = []
+    for definition in definitions:
+        if isinstance(definition, DimensionExtraFieldDefinition):
+            coerced.append(definition)
+        else:
+            coerced.append(DimensionExtraFieldDefinition.model_validate(definition))
+
+    for definition in coerced:
+        key = definition.key.strip()
+        if not key:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Dimension field keys cannot be empty.",
+            )
+
+        normalised = _normalise_key(key)
+        if not normalised:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Invalid dimension field key '{definition.key}'.",
+            )
+
+        if normalised in normalised_keys:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Duplicate dimension field key '{definition.key}'.",
+            )
+
+        if definition.data_type not in SUPPORTED_FIELD_TYPES:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Unsupported data type '{definition.data_type}'.",
+            )
+
+        normalised_keys.add(normalised)
+        validated.append(
+            {
+                "key": key,
+                "label": definition.label,
+                "description": definition.description,
+                "data_type": definition.data_type,
+                "required": definition.required,
+            }
+        )
+
+    logger.debug("Validated dimension extra fields", extra={"count": len(validated)})
+    return validated
+
+
+def get_dimension_by_code(session: Session, code: str) -> Dimension | None:
+    return session.exec(select(Dimension).where(Dimension.code == code)).first()
+
+
+def require_dimension(session: Session, code: str) -> Dimension:
+    dimension = get_dimension_by_code(session, code)
+    if not dimension:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Dimension '{code}' not found.",
+        )
+    return dimension
+
+
+def _coerce_value(value: Any, data_type: str) -> Any:
+    if value is None or (isinstance(value, str) and not value.strip()):
+        return None
+
+    if data_type == "string":
+        return str(value).strip()
+
+    if data_type == "number":
+        try:
+            return float(value)
+        except (TypeError, ValueError) as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Value '{value}' is not a valid number.",
+            ) from exc
+
+    if data_type == "boolean":
+        if isinstance(value, bool):
+            return value
+        text = str(value).strip().lower()
+        if text in {"true", "1", "yes", "y"}:
+            return True
+        if text in {"false", "0", "no", "n"}:
+            return False
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Value '{value}' is not a valid boolean.",
+        )
+
+    return value
+
+
+def build_schema_lookup(
+    extra_schema: Iterable[dict[str, Any]]
+) -> dict[str, dict[str, Any]]:
+    lookup: dict[str, dict[str, Any]] = {}
+    for definition in extra_schema:
+        key = definition.get("key")
+        if not key:
+            continue
+        lookup[_normalise_key(key)] = definition
+        label = definition.get("label")
+        if label:
+            lookup.setdefault(_normalise_key(label), definition)
+    return lookup
+
+
+def validate_attributes(
+    dimension: Dimension, attributes: dict[str, Any] | None
+) -> dict[str, Any]:
+    attributes = attributes or {}
+    if not dimension.extra_schema:
+        filtered = {k: v for k, v in attributes.items() if v is not None}
+        logger.debug(
+            "Dimension has no extra schema; stripped to %s keys", len(filtered)
+        )
+        return filtered
+
+    lookup = build_schema_lookup(dimension.extra_schema)
+    cleaned: dict[str, Any] = {}
+
+    for raw_key, raw_value in attributes.items():
+        schema = lookup.get(_normalise_key(raw_key))
+        if not schema:
+            logger.debug(
+                "Ignoring attribute for undefined key", extra={"key": raw_key}
+            )
+            continue
+
+        coerced = _coerce_value(raw_value, schema.get("data_type", "string"))
+        cleaned[schema["key"]] = coerced
+
+    for definition in dimension.extra_schema:
+        if definition.get("required") and cleaned.get(definition["key"]) is None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Missing required attribute '{definition['key']}'.",
+            )
+
+    logger.debug(
+        "Validated canonical attributes", extra={"dimension": dimension.code}
+    )
+    return cleaned
+
+
+def dimension_to_read_model(dimension: Dimension) -> DimensionRead:
+    extra_fields = [
+        DimensionExtraFieldDefinition.model_validate(field)
+        for field in dimension.extra_schema
+    ]
+    return DimensionRead(
+        id=dimension.id,
+        code=dimension.code,
+        label=dimension.label,
+        description=dimension.description,
+        extra_fields=extra_fields,
+        created_at=dimension.created_at,
+        updated_at=dimension.updated_at,
+    )
+
+
+def relation_to_read_model(
+    relation: DimensionRelation, parent: Dimension, child: Dimension, link_count: int
+) -> DimensionRelationRead:
+    payload = DimensionRelationRead(
+        id=relation.id,
+        label=relation.label,
+        description=relation.description,
+        parent_dimension_code=relation.parent_dimension_code,
+        child_dimension_code=relation.child_dimension_code,
+        parent_dimension=dimension_to_read_model(parent),
+        child_dimension=dimension_to_read_model(child),
+        link_count=link_count,
+        created_at=relation.created_at,
+        updated_at=relation.updated_at,
+    )
+    logger.debug(
+        "Serialised dimension relation", extra={"relation_id": relation.id}
+    )
+    return payload
+
+
+def ensure_dimension_can_be_removed(session: Session, code: str) -> None:
+    """Ensure a dimension is not referenced before deletion."""
+
+    canonical_count = session.exec(
+        select(CanonicalValue).where(CanonicalValue.dimension == code)
+    ).all()
+    if canonical_count:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Cannot delete a dimension that still has canonical values.",
+        )
+
+    relation_count = session.exec(
+        select(DimensionRelation).where(
+            (DimensionRelation.parent_dimension_code == code)
+            | (DimensionRelation.child_dimension_code == code)
+        )
+    ).all()
+    if relation_count:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Cannot delete a dimension that participates in relations.",
+        )
+
+
+def remove_links_for_canonical(session: Session, canonical_id: int) -> None:
+    links = session.exec(
+        select(DimensionRelationLink).where(
+            (DimensionRelationLink.parent_canonical_id == canonical_id)
+            | (DimensionRelationLink.child_canonical_id == canonical_id)
+        )
+    ).all()
+    for link in links:
+        session.delete(link)
+

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -8,3 +8,5 @@ numpy<2
 openai==0.28.1
 python-multipart==0.0.9
 httpx==0.27.2
+pandas==2.1.4
+openpyxl==3.1.2

--- a/docs/CANONICAL_LIBRARY.md
+++ b/docs/CANONICAL_LIBRARY.md
@@ -6,12 +6,17 @@ UI and provides an Abu Dhabi–specific dataset ready for import.
 
 ## Page overview
 
-The library page offers four key capabilities:
+The library page offers five key capabilities:
 
 1. **Filter & search** – Narrow the table by dimension and/or keyword to locate existing canonical values quickly.
-2. **Create & edit** – Launch the editor modal to add brand-new entries or update labels, dimensions, and descriptions.
-3. **Bulk import** – Paste a tab- or comma-delimited payload to create many canonical rows at once.
-4. **Export** – Download the filtered table to CSV for auditing or offline collaboration.
+2. **Create & edit** – Launch the editor modal to add brand-new entries or update labels, dimensions, descriptions, and any
+   dimension-specific attributes.
+3. **Bulk import** – Upload CSV/TSV/Excel files or paste tabular rows and let the importer detect headers, attributes, and
+   dimensions automatically.
+4. **Attributes** – Capture the extra fields defined for the active dimension (for example, codes or international identifiers)
+   alongside each canonical value.
+5. **Export** – Download the filtered table to CSV for auditing or offline collaboration. The export includes attribute columns
+   so downstream tools can preserve the additional metadata.
 
 All changes are persisted via the `/api/reference/canonical` endpoints exposed by the FastAPI backend.
 
@@ -25,14 +30,15 @@ All changes are persisted via the `/api/reference/canonical` endpoints exposed b
 
 ## Bulk import walkthrough
 
-The importer expects rows in the following structure:
+The importer accepts CSV, TSV, or Excel workbooks. Provide a header row describing each column—`dimension`, `label`, and
+`description` columns are detected automatically, along with any extra attribute keys defined for the target dimension. When
+pasting rows directly into the modal, the same headers should appear in the first line.
 
-```
-dimension\tcanonical label\t(optional description columns)
-```
-
-* Columns can be separated by tabs, commas, or 2+ spaces. Additional columns are concatenated into the description.
-* Empty dimension cells inherit the "Default dimension" value provided in the modal (useful when pasting single-dimension data).
+* Columns can be separated by commas, tabs, or multiple spaces when pasting raw text.
+* Empty dimension cells inherit the "Default dimension" value provided in the modal (useful when supplying single-dimension data).
+* Any attribute columns that match the dimension's schema (for example `code`, `iso_code`, or `unesco_level`) are parsed and
+  stored alongside the canonical value.
+* Uploading both a file and pasted rows prioritises the file contents; remove the file to import the pasted data instead.
 
 ### Abu Dhabi regional dataset
 
@@ -47,15 +53,17 @@ To bulk load the dataset:
    cat docs/data/abu_dhabi_canonical.tsv
    ```
 2. Copy all rows starting from the second line (skip the header row).
-3. In the Reviewer UI, select **Bulk import** → paste the copied rows → click **Import rows**.
-4. The importer reports how many records were created and automatically sorts them alongside existing values.
+3. In the Reviewer UI, select **Bulk import** → either upload the TSV file or paste the copied rows → click **Import rows**.
+4. The importer reports how many records were created, highlights any issues inline, and automatically sorts the additions alongside existing values.
 
 ### Tips for custom datasets
 
-- Include stable identifiers (codes) in the description field so downstream consumers can map raw values reliably.
+- Include stable identifiers (codes) either in dedicated attribute columns or the description so downstream consumers can map raw values reliably.
 - Use consistent dimensions (e.g., `region`, `district`, `currency`) to keep filtering predictable.
 - When storing multilingual labels, concatenate translations with clear separators, for example: `English | Arabic`.
 - The importer ignores blank lines and lines prefixed with `#`, enabling lightweight in-line commentary.
+- For spreadsheet imports, multiple worksheets are supported—only the first sheet is read by default. Save each dataset as a
+  separate file for clarity.
 
 ## Troubleshooting
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -2,8 +2,10 @@
 
 ## 1. Core Reference Data Service
 - Maintain authoritative mappings for key dimensions such as marital status, education, nationality, and employment status.
+- Curate the dimension catalog itself, including machine-friendly codes, reviewer labels, descriptions, and custom attribute schemas.
 - Capture synonyms and spelling variations (e.g., "Single", "Unmarried", "Never married").
 - Provide multilingual metadata to support future international roll-outs.
+- Model parent/child relationships between dimensions (e.g., region → district) and capture the canonical value pairings needed for drill-down analytics.
 
 ## 2. Semantic Matching
 - Use NLP and embedding models to suggest standardized values for new raw inputs.

--- a/reviewer-ui/src/App.test.tsx
+++ b/reviewer-ui/src/App.test.tsx
@@ -16,9 +16,11 @@ vi.mock('./state/AppStateContext', () => ({
   useAppState: () => ({
     config: { matcher_backend: 'embedding' },
     canonicalValues: [],
+    dimensions: [],
     isLoading: mockIsLoading,
     loadError: mockLoadError,
     refresh: refreshMock,
+    updateDimensions: vi.fn(),
   }),
 }));
 

--- a/reviewer-ui/src/App.tsx
+++ b/reviewer-ui/src/App.tsx
@@ -9,6 +9,8 @@ import MappingHistoryPage from './pages/MappingHistoryPage';
 import MatchInsightsPage from './pages/MatchInsightsPage';
 import SuggestionsPage from './pages/SuggestionsPage';
 import CanonicalLibraryPage from './pages/CanonicalLibraryPage';
+import DimensionsPage from './pages/DimensionsPage';
+import DimensionRelationsPage from './pages/DimensionRelationsPage';
 import { AppStateProvider, useAppState } from './state/AppStateContext';
 import { applyTheme, themeDefinitions, themeOrder, ThemeChoice } from './themes';
 import type { ToastMessage } from './types';
@@ -29,7 +31,9 @@ interface NavItem {
 
 const navItems: NavItem[] = [
   { path: '/dashboard', label: 'Dashboard' },
+  { path: '/dimensions', label: 'Dimensions' },
   { path: '/canonical-library', label: 'Canonical Library' },
+  { path: '/dimension-relations', label: 'Dimension Relations' },
   { path: '/connections', label: 'Source Connections' },
   { path: '/field-mappings', label: 'Field Mappings' },
   { path: '/match-insights', label: 'Match Insights' },
@@ -167,7 +171,9 @@ const AppScaffold = ({
             <Routes>
               <Route path="/" element={<Navigate to="/dashboard" replace />} />
               <Route path="/dashboard" element={<DashboardPage onToast={onToast} />} />
+              <Route path="/dimensions" element={<DimensionsPage onToast={onToast} />} />
               <Route path="/canonical-library" element={<CanonicalLibraryPage onToast={onToast} />} />
+              <Route path="/dimension-relations" element={<DimensionRelationsPage onToast={onToast} />} />
               <Route path="/connections" element={<ConnectionsPage onToast={onToast} />} />
               <Route path="/field-mappings" element={<FieldMappingsPage onToast={onToast} />} />
               <Route path="/match-insights" element={<MatchInsightsPage onToast={onToast} />} />

--- a/reviewer-ui/src/api.ts
+++ b/reviewer-ui/src/api.ts
@@ -1,6 +1,15 @@
 import type {
+  BulkImportResult,
   CanonicalValue,
   CanonicalValueUpdatePayload,
+  DimensionCreatePayload,
+  DimensionDefinition,
+  DimensionRelationCreatePayload,
+  DimensionRelationLink,
+  DimensionRelationLinkPayload,
+  DimensionRelationSummary,
+  DimensionRelationUpdatePayload,
+  DimensionUpdatePayload,
   FieldMatchStats,
   MatchResponse,
   SourceConnection,
@@ -131,12 +140,99 @@ export async function deleteCanonicalValue(id: number): Promise<void> {
   await apiFetchVoid(`/api/reference/canonical/${id}`, { method: 'DELETE' });
 }
 
+export async function bulkImportCanonicalValues(formData: FormData): Promise<BulkImportResult> {
+  return apiFetchJson<BulkImportResult>('/api/reference/canonical/import', {
+    method: 'POST',
+    body: formData,
+  });
+}
+
 export async function proposeMatch(raw_text: string, dimension?: string): Promise<MatchResponse> {
   return apiFetchJson<MatchResponse>('/api/reference/propose', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ raw_text, dimension }),
   });
+}
+
+export async function fetchDimensions(): Promise<DimensionDefinition[]> {
+  return apiFetchJson<DimensionDefinition[]>('/api/reference/dimensions');
+}
+
+export async function createDimension(payload: DimensionCreatePayload): Promise<DimensionDefinition> {
+  return apiFetchJson<DimensionDefinition>('/api/reference/dimensions', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function updateDimension(
+  code: string,
+  payload: DimensionUpdatePayload,
+): Promise<DimensionDefinition> {
+  return apiFetchJson<DimensionDefinition>(`/api/reference/dimensions/${encodeURIComponent(code)}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function deleteDimension(code: string): Promise<void> {
+  await apiFetchVoid(`/api/reference/dimensions/${encodeURIComponent(code)}`, { method: 'DELETE' });
+}
+
+export async function fetchDimensionRelations(): Promise<DimensionRelationSummary[]> {
+  return apiFetchJson<DimensionRelationSummary[]>('/api/reference/dimension-relations');
+}
+
+export async function createDimensionRelation(
+  payload: DimensionRelationCreatePayload,
+): Promise<DimensionRelationSummary> {
+  return apiFetchJson<DimensionRelationSummary>('/api/reference/dimension-relations', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function updateDimensionRelation(
+  relationId: number,
+  payload: DimensionRelationUpdatePayload,
+): Promise<DimensionRelationSummary> {
+  return apiFetchJson<DimensionRelationSummary>(`/api/reference/dimension-relations/${relationId}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function deleteDimensionRelation(relationId: number): Promise<void> {
+  await apiFetchVoid(`/api/reference/dimension-relations/${relationId}`, { method: 'DELETE' });
+}
+
+export async function fetchDimensionRelationLinks(
+  relationId: number,
+): Promise<DimensionRelationLink[]> {
+  return apiFetchJson<DimensionRelationLink[]>(`/api/reference/dimension-relations/${relationId}/links`);
+}
+
+export async function createDimensionRelationLink(
+  relationId: number,
+  payload: DimensionRelationLinkPayload,
+): Promise<DimensionRelationLink> {
+  return apiFetchJson<DimensionRelationLink>(`/api/reference/dimension-relations/${relationId}/links`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function deleteDimensionRelationLink(
+  relationId: number,
+  linkId: number,
+): Promise<void> {
+  await apiFetchVoid(`/api/reference/dimension-relations/${relationId}/links/${linkId}`, { method: 'DELETE' });
 }
 
 export async function fetchConfig(): Promise<SystemConfig> {

--- a/reviewer-ui/src/pages/DimensionRelationsPage.tsx
+++ b/reviewer-ui/src/pages/DimensionRelationsPage.tsx
@@ -1,0 +1,654 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  Badge,
+  Button,
+  Card,
+  Col,
+  Form,
+  Modal,
+  Row,
+  Spinner,
+  Table,
+} from 'react-bootstrap';
+
+import {
+  createDimensionRelation,
+  createDimensionRelationLink,
+  deleteDimensionRelation,
+  deleteDimensionRelationLink,
+  fetchDimensionRelationLinks,
+  fetchDimensionRelations,
+  updateDimensionRelation,
+} from '../api';
+import { useAppState } from '../state/AppStateContext';
+import type {
+  DimensionRelationCreatePayload,
+  DimensionRelationLink,
+  DimensionRelationSummary,
+  DimensionRelationUpdatePayload,
+  ToastMessage,
+} from '../types';
+
+interface DimensionRelationsPageProps {
+  onToast: (toast: ToastMessage) => void;
+}
+
+interface LinkDraft {
+  parentId: number | ''; 
+  childId: number | '';
+}
+
+const DimensionRelationsPage = ({ onToast }: DimensionRelationsPageProps) => {
+  const { dimensions, canonicalValues } = useAppState();
+  const [relations, setRelations] = useState<DimensionRelationSummary[]>([]);
+  const [linksByRelation, setLinksByRelation] = useState<Map<number, DimensionRelationLink[]>>(new Map());
+  const [selectedRelationId, setSelectedRelationId] = useState<number | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isLinkSubmitting, setIsLinkSubmitting] = useState(false);
+  const [linksLoading, setLinksLoading] = useState(false);
+  const [showRelationModal, setShowRelationModal] = useState(false);
+  const [editingRelation, setEditingRelation] = useState<DimensionRelationSummary | null>(null);
+  const [relationDraft, setRelationDraft] = useState<DimensionRelationCreatePayload>({
+    label: '',
+    parent_dimension_code: '',
+    child_dimension_code: '',
+    description: '',
+  });
+  const [linkDraft, setLinkDraft] = useState<LinkDraft>({ parentId: '', childId: '' });
+  const [deleteRelationTarget, setDeleteRelationTarget] = useState<DimensionRelationSummary | null>(null);
+  const [deleteLinkTarget, setDeleteLinkTarget] = useState<{ relationId: number; linkId: number } | null>(null);
+
+  const dimensionOptions = useMemo(
+    () => dimensions.map((dimension) => ({ code: dimension.code, label: dimension.label })),
+    [dimensions],
+  );
+
+  const selectedRelation = useMemo(
+    () => relations.find((relation) => relation.id === selectedRelationId) ?? null,
+    [relations, selectedRelationId],
+  );
+
+  const parentCandidates = useMemo(() => {
+    if (!selectedRelation) {
+      return [];
+    }
+    return canonicalValues.filter((value) => value.dimension === selectedRelation.parent_dimension_code);
+  }, [canonicalValues, selectedRelation]);
+
+  const childCandidates = useMemo(() => {
+    if (!selectedRelation) {
+      return [];
+    }
+    return canonicalValues.filter((value) => value.dimension === selectedRelation.child_dimension_code);
+  }, [canonicalValues, selectedRelation]);
+
+  useEffect(() => {
+    const loadRelations = async () => {
+      setIsLoading(true);
+      try {
+        const result = await fetchDimensionRelations();
+        setRelations(result);
+        if (result.length > 0) {
+          setSelectedRelationId(result[0].id);
+        } else {
+          setSelectedRelationId(null);
+        }
+      } catch (error: unknown) {
+        console.error(error);
+        onToast({ type: 'error', content: 'Unable to load dimension relations.' });
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    void loadRelations();
+  }, [onToast]);
+
+  useEffect(() => {
+    if (selectedRelationId === null || linksByRelation.has(selectedRelationId)) {
+      return;
+    }
+    const loadLinks = async () => {
+      setLinksLoading(true);
+      try {
+        const links = await fetchDimensionRelationLinks(selectedRelationId);
+        setLinksByRelation((prev) => new Map(prev).set(selectedRelationId, links));
+      } catch (error: unknown) {
+        console.error(error);
+        onToast({ type: 'error', content: 'Unable to load relation links.' });
+      } finally {
+        setLinksLoading(false);
+      }
+    };
+
+    void loadLinks();
+  }, [linksByRelation, onToast, selectedRelationId]);
+
+  const openCreateModal = () => {
+    setEditingRelation(null);
+    setRelationDraft({ label: '', parent_dimension_code: '', child_dimension_code: '', description: '' });
+    setShowRelationModal(true);
+  };
+
+  const openEditModal = (relation: DimensionRelationSummary) => {
+    setEditingRelation(relation);
+    setRelationDraft({
+      label: relation.label,
+      parent_dimension_code: relation.parent_dimension_code,
+      child_dimension_code: relation.child_dimension_code,
+      description: relation.description ?? '',
+    });
+    setShowRelationModal(true);
+  };
+
+  const resetRelationModal = () => {
+    setShowRelationModal(false);
+    setEditingRelation(null);
+    setRelationDraft({ label: '', parent_dimension_code: '', child_dimension_code: '', description: '' });
+  };
+
+  const handleSaveRelation = async () => {
+    if (!relationDraft.label.trim() || !relationDraft.parent_dimension_code || !relationDraft.child_dimension_code) {
+      onToast({ type: 'error', content: 'Label, parent dimension, and child dimension are required.' });
+      return;
+    }
+
+    if (relationDraft.parent_dimension_code === relationDraft.child_dimension_code) {
+      onToast({ type: 'error', content: 'Parent and child dimensions must be different.' });
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      if (editingRelation) {
+        const payload: DimensionRelationUpdatePayload = {
+          label: relationDraft.label.trim(),
+          description: relationDraft.description?.trim() || undefined,
+        };
+        const updated = await updateDimensionRelation(editingRelation.id, payload);
+        setRelations((prev) => prev.map((relation) => (relation.id === updated.id ? updated : relation)));
+        onToast({ type: 'success', content: 'Relation updated.' });
+      } else {
+        const payload: DimensionRelationCreatePayload = {
+          label: relationDraft.label.trim(),
+          parent_dimension_code: relationDraft.parent_dimension_code,
+          child_dimension_code: relationDraft.child_dimension_code,
+          description: relationDraft.description?.trim() || undefined,
+        };
+        const created = await createDimensionRelation(payload);
+        setRelations((prev) => [...prev, created]);
+        setSelectedRelationId(created.id);
+        onToast({ type: 'success', content: 'Relation created.' });
+      }
+      resetRelationModal();
+    } catch (error: unknown) {
+      console.error(error);
+      onToast({ type: 'error', content: 'Unable to save relation.' });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleDeleteRelation = async () => {
+    if (!deleteRelationTarget) {
+      return;
+    }
+    setIsSubmitting(true);
+    try {
+      await deleteDimensionRelation(deleteRelationTarget.id);
+      setRelations((prev) => {
+        const remaining = prev.filter((relation) => relation.id !== deleteRelationTarget.id);
+        if (selectedRelationId === deleteRelationTarget.id) {
+          setSelectedRelationId(remaining.length ? remaining[0].id : null);
+        }
+        return remaining;
+      });
+      setLinksByRelation((prev) => {
+        const next = new Map(prev);
+        next.delete(deleteRelationTarget.id);
+        return next;
+      });
+      onToast({ type: 'success', content: 'Relation deleted.' });
+      setDeleteRelationTarget(null);
+    } catch (error: unknown) {
+      console.error(error);
+      onToast({ type: 'error', content: 'Unable to delete relation.' });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleCreateLink = async () => {
+    if (!selectedRelation || !linkDraft.parentId || !linkDraft.childId) {
+      onToast({ type: 'error', content: 'Select both parent and child canonical values.' });
+      return;
+    }
+
+    setIsLinkSubmitting(true);
+    try {
+      const created = await createDimensionRelationLink(selectedRelation.id, {
+        parent_canonical_id: linkDraft.parentId,
+        child_canonical_id: linkDraft.childId,
+      });
+      setLinksByRelation((prev) => {
+        const next = new Map(prev);
+        const current = next.get(selectedRelation.id) ?? [];
+        next.set(selectedRelation.id, [...current, created]);
+        return next;
+      });
+      setRelations((prev) =>
+        prev.map((relation) =>
+          relation.id === selectedRelation.id
+            ? { ...relation, link_count: relation.link_count + 1 }
+            : relation,
+        ),
+      );
+      setLinkDraft({ parentId: '', childId: '' });
+      onToast({ type: 'success', content: 'Relation link created.' });
+    } catch (error: unknown) {
+      console.error(error);
+      onToast({ type: 'error', content: 'Unable to create relation link.' });
+    } finally {
+      setIsLinkSubmitting(false);
+    }
+  };
+
+  const handleDeleteLink = async () => {
+    if (!deleteLinkTarget) {
+      return;
+    }
+    setIsLinkSubmitting(true);
+    try {
+      await deleteDimensionRelationLink(deleteLinkTarget.relationId, deleteLinkTarget.linkId);
+      setLinksByRelation((prev) => {
+        const next = new Map(prev);
+        const current = next.get(deleteLinkTarget.relationId) ?? [];
+        next.set(
+          deleteLinkTarget.relationId,
+          current.filter((link) => link.id !== deleteLinkTarget.linkId),
+        );
+        return next;
+      });
+      setRelations((prev) =>
+        prev.map((relation) =>
+          relation.id === deleteLinkTarget.relationId
+            ? { ...relation, link_count: Math.max(relation.link_count - 1, 0) }
+            : relation,
+        ),
+      );
+      onToast({ type: 'success', content: 'Relation link deleted.' });
+      setDeleteLinkTarget(null);
+    } catch (error: unknown) {
+      console.error(error);
+      onToast({ type: 'error', content: 'Unable to delete relation link.' });
+    } finally {
+      setIsLinkSubmitting(false);
+    }
+  };
+
+  const currentLinks = selectedRelationId ? linksByRelation.get(selectedRelationId) ?? [] : [];
+
+  return (
+    <div className="d-flex flex-column gap-4" aria-label="Dimension relations">
+      <Card className="card-section">
+        <Card.Body className="d-flex flex-column gap-4">
+          <div className="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center gap-3">
+            <div>
+              <Card.Title as="h1" className="section-heading h4 mb-1">
+                Dimension relationships
+              </Card.Title>
+              <Card.Text className="text-body-secondary mb-0">
+                Model parent-child relationships between dimensions—for example, regions and their districts. Maintain
+                canonical value pairings to power drill-downs and validation rules.
+              </Card.Text>
+            </div>
+            <Button variant="primary" onClick={openCreateModal}>
+              New relation
+            </Button>
+          </div>
+
+          {isLoading ? (
+            <div className="d-flex justify-content-center py-5">
+              <Spinner animation="border" role="status" aria-hidden="true" />
+            </div>
+          ) : relations.length === 0 ? (
+            <div className="text-center text-body-secondary py-5">
+              <p className="mb-0">No relations defined yet. Create a relation to begin linking canonical values.</p>
+            </div>
+          ) : (
+            <Row className="g-3">
+              {relations.map((relation) => (
+                <Col key={relation.id} md={6} xl={4}>
+                  <Card
+                    className={`h-100 ${
+                      relation.id === selectedRelationId ? 'border-primary border-2 shadow-sm' : 'border-0 shadow-sm'
+                    }`}
+                    onClick={() => setSelectedRelationId(relation.id)}
+                    role="button"
+                    style={{ cursor: 'pointer' }}
+                  >
+                    <Card.Body className="d-flex flex-column gap-3">
+                      <div className="d-flex justify-content-between align-items-start gap-3">
+                        <div>
+                          <Card.Title as="h2" className="h5 mb-1">
+                            {relation.label}
+                          </Card.Title>
+                          <Card.Text className="text-body-secondary mb-0">
+                            {relation.description || 'No description provided.'}
+                          </Card.Text>
+                        </div>
+                        <Badge bg="secondary" pill>
+                          {relation.link_count} link{relation.link_count === 1 ? '' : 's'}
+                        </Badge>
+                      </div>
+                      <div className="d-flex flex-column gap-2">
+                        <div className="d-flex align-items-center gap-2">
+                          <Badge bg="info" text="dark">
+                            Parent
+                          </Badge>
+                          <span>
+                            {relation.parent_dimension.label} ({relation.parent_dimension.code})
+                          </span>
+                        </div>
+                        <div className="d-flex align-items-center gap-2">
+                          <Badge bg="warning" text="dark">
+                            Child
+                          </Badge>
+                          <span>
+                            {relation.child_dimension.label} ({relation.child_dimension.code})
+                          </span>
+                        </div>
+                      </div>
+                      <div className="d-flex gap-2 mt-auto">
+                        <Button variant="outline-primary" size="sm" onClick={() => openEditModal(relation)}>
+                          Edit
+                        </Button>
+                        <Button variant="outline-danger" size="sm" onClick={() => setDeleteRelationTarget(relation)}>
+                          Delete
+                        </Button>
+                      </div>
+                    </Card.Body>
+                  </Card>
+                </Col>
+              ))}
+            </Row>
+          )}
+        </Card.Body>
+      </Card>
+
+      {selectedRelation && (
+        <Card className="card-section">
+          <Card.Body className="d-flex flex-column gap-4">
+            <div className="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center gap-3">
+              <div>
+                <Card.Title as="h2" className="h4 mb-1">
+                  {selectedRelation.label}
+                </Card.Title>
+                <Card.Text className="text-body-secondary mb-0">
+                  {selectedRelation.parent_dimension.label} ➝ {selectedRelation.child_dimension.label}
+                </Card.Text>
+              </div>
+            </div>
+
+            <Card className="border-0 shadow-sm">
+              <Card.Body className="d-flex flex-column gap-3">
+                <h3 className="h6 mb-0">Add link</h3>
+                <Row className="g-3 align-items-end">
+                  <Col md={6}>
+                    <Form.Group controlId="relation-parent-select">
+                      <Form.Label>Parent canonical value</Form.Label>
+                      <Form.Select
+                        value={linkDraft.parentId === '' ? '' : String(linkDraft.parentId)}
+                        onChange={(event) =>
+                          setLinkDraft((prev) => ({
+                            ...prev,
+                            parentId: event.target.value ? Number(event.target.value) : '',
+                          }))
+                        }
+                      >
+                        <option value="">Select parent value</option>
+                        {parentCandidates.map((value) => (
+                          <option key={value.id} value={value.id}>
+                            {value.canonical_label}
+                          </option>
+                        ))}
+                      </Form.Select>
+                      {parentCandidates.length === 0 && (
+                        <Form.Text className="text-body-secondary">
+                          No canonical values found for {selectedRelation.parent_dimension.label}. Add values first.
+                        </Form.Text>
+                      )}
+                    </Form.Group>
+                  </Col>
+                  <Col md={6}>
+                    <Form.Group controlId="relation-child-select">
+                      <Form.Label>Child canonical value</Form.Label>
+                      <Form.Select
+                        value={linkDraft.childId === '' ? '' : String(linkDraft.childId)}
+                        onChange={(event) =>
+                          setLinkDraft((prev) => ({
+                            ...prev,
+                            childId: event.target.value ? Number(event.target.value) : '',
+                          }))
+                        }
+                      >
+                        <option value="">Select child value</option>
+                        {childCandidates.map((value) => (
+                          <option key={value.id} value={value.id}>
+                            {value.canonical_label}
+                          </option>
+                        ))}
+                      </Form.Select>
+                      {childCandidates.length === 0 && (
+                        <Form.Text className="text-body-secondary">
+                          No canonical values found for {selectedRelation.child_dimension.label}. Add values first.
+                        </Form.Text>
+                      )}
+                    </Form.Group>
+                  </Col>
+                </Row>
+                <div>
+                  <Button
+                    variant="primary"
+                    onClick={() => void handleCreateLink()}
+                    disabled={isLinkSubmitting || parentCandidates.length === 0 || childCandidates.length === 0}
+                  >
+                    {isLinkSubmitting ? (
+                      <span className="d-inline-flex align-items-center gap-2">
+                        <Spinner animation="border" size="sm" role="status" aria-hidden="true" />
+                        Linking…
+                      </span>
+                    ) : (
+                      'Create link'
+                    )}
+                  </Button>
+                </div>
+              </Card.Body>
+            </Card>
+
+            <div className="table-responsive">
+              <Table striped hover className="align-middle table-nowrap">
+                <thead>
+                  <tr>
+                    <th>Parent value</th>
+                    <th>Child value</th>
+                    <th className="text-end">Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {linksLoading ? (
+                    <tr>
+                      <td colSpan={3} className="text-center py-4">
+                        <Spinner animation="border" role="status" aria-hidden="true" />
+                      </td>
+                    </tr>
+                  ) : currentLinks.length === 0 ? (
+                    <tr>
+                      <td colSpan={3} className="text-center text-body-secondary py-4">
+                        No links defined yet for this relation.
+                      </td>
+                    </tr>
+                  ) : (
+                    currentLinks.map((link) => (
+                      <tr key={link.id}>
+                        <td>{link.parent_label}</td>
+                        <td>{link.child_label}</td>
+                        <td className="text-end">
+                          <Button
+                            size="sm"
+                            variant="outline-danger"
+                            onClick={() => setDeleteLinkTarget({ relationId: selectedRelation.id, linkId: link.id })}
+                          >
+                            Delete
+                          </Button>
+                        </td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </Table>
+            </div>
+          </Card.Body>
+        </Card>
+      )}
+
+      <Modal show={showRelationModal} onHide={resetRelationModal} centered>
+        <Modal.Header closeButton>
+          <Modal.Title>{editingRelation ? 'Edit relation' : 'New relation'}</Modal.Title>
+        </Modal.Header>
+        <Modal.Body className="d-flex flex-column gap-3">
+          <Form.Group controlId="relation-label">
+            <Form.Label>Label</Form.Label>
+            <Form.Control
+              type="text"
+              value={relationDraft.label}
+              onChange={(event) => setRelationDraft((prev) => ({ ...prev, label: event.target.value }))}
+              placeholder="e.g. Region to District"
+            />
+          </Form.Group>
+          <Row className="g-3">
+            <Col md={6}>
+              <Form.Group controlId="relation-parent-dimension">
+                <Form.Label>Parent dimension</Form.Label>
+                <Form.Select
+                  value={relationDraft.parent_dimension_code}
+                  onChange={(event) =>
+                    setRelationDraft((prev) => ({ ...prev, parent_dimension_code: event.target.value }))
+                  }
+                  disabled={Boolean(editingRelation)}
+                >
+                  <option value="">Select parent dimension</option>
+                  {dimensionOptions.map((option) => (
+                    <option key={option.code} value={option.code}>
+                      {option.label} ({option.code})
+                    </option>
+                  ))}
+                </Form.Select>
+              </Form.Group>
+            </Col>
+            <Col md={6}>
+              <Form.Group controlId="relation-child-dimension">
+                <Form.Label>Child dimension</Form.Label>
+                <Form.Select
+                  value={relationDraft.child_dimension_code}
+                  onChange={(event) =>
+                    setRelationDraft((prev) => ({ ...prev, child_dimension_code: event.target.value }))
+                  }
+                  disabled={Boolean(editingRelation)}
+                >
+                  <option value="">Select child dimension</option>
+                  {dimensionOptions.map((option) => (
+                    <option key={option.code} value={option.code}>
+                      {option.label} ({option.code})
+                    </option>
+                  ))}
+                </Form.Select>
+              </Form.Group>
+            </Col>
+          </Row>
+          <Form.Group controlId="relation-description">
+            <Form.Label>Description</Form.Label>
+            <Form.Control
+              as="textarea"
+              rows={3}
+              value={relationDraft.description ?? ''}
+              onChange={(event) => setRelationDraft((prev) => ({ ...prev, description: event.target.value }))}
+              placeholder="Optional description for analysts"
+            />
+          </Form.Group>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button variant="outline-secondary" onClick={resetRelationModal}>
+            Cancel
+          </Button>
+          <Button variant="primary" onClick={() => void handleSaveRelation()} disabled={isSubmitting}>
+            {isSubmitting ? (
+              <span className="d-inline-flex align-items-center gap-2">
+                <Spinner animation="border" size="sm" role="status" aria-hidden="true" />
+                Saving…
+              </span>
+            ) : (
+              'Save'
+            )}
+          </Button>
+        </Modal.Footer>
+      </Modal>
+
+      <Modal show={Boolean(deleteRelationTarget)} onHide={() => setDeleteRelationTarget(null)} centered>
+        <Modal.Header closeButton>
+          <Modal.Title>Delete relation</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          Delete the relation <strong>{deleteRelationTarget?.label}</strong>? This removes all links between
+          {deleteRelationTarget && (
+            <>
+              {' '}
+              <strong>{deleteRelationTarget.parent_dimension.label}</strong> and{' '}
+              <strong>{deleteRelationTarget.child_dimension.label}</strong> values.
+            </>
+          )}
+        </Modal.Body>
+        <Modal.Footer>
+          <Button variant="outline-secondary" onClick={() => setDeleteRelationTarget(null)}>
+            Cancel
+          </Button>
+          <Button variant="danger" onClick={() => void handleDeleteRelation()} disabled={isSubmitting}>
+            {isSubmitting ? (
+              <span className="d-inline-flex align-items-center gap-2">
+                <Spinner animation="border" size="sm" role="status" aria-hidden="true" />
+                Deleting…
+              </span>
+            ) : (
+              'Delete'
+            )}
+          </Button>
+        </Modal.Footer>
+      </Modal>
+
+      <Modal show={Boolean(deleteLinkTarget)} onHide={() => setDeleteLinkTarget(null)} centered>
+        <Modal.Header closeButton>
+          <Modal.Title>Delete relation link</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>Remove this parent-child pairing from the relation?</Modal.Body>
+        <Modal.Footer>
+          <Button variant="outline-secondary" onClick={() => setDeleteLinkTarget(null)}>
+            Cancel
+          </Button>
+          <Button variant="danger" onClick={() => void handleDeleteLink()} disabled={isLinkSubmitting}>
+            {isLinkSubmitting ? (
+              <span className="d-inline-flex align-items-center gap-2">
+                <Spinner animation="border" size="sm" role="status" aria-hidden="true" />
+                Deleting…
+              </span>
+            ) : (
+              'Delete'
+            )}
+          </Button>
+        </Modal.Footer>
+      </Modal>
+    </div>
+  );
+};
+
+export default DimensionRelationsPage;

--- a/reviewer-ui/src/pages/DimensionsPage.tsx
+++ b/reviewer-ui/src/pages/DimensionsPage.tsx
@@ -1,0 +1,462 @@
+import { useMemo, useState } from 'react';
+import {
+  Badge,
+  Button,
+  Card,
+  Col,
+  Form,
+  Modal,
+  Row,
+  Spinner,
+  Table,
+} from 'react-bootstrap';
+
+import {
+  createDimension,
+  deleteDimension,
+  updateDimension,
+} from '../api';
+import { useAppState } from '../state/AppStateContext';
+import type {
+  DimensionCreatePayload,
+  DimensionDefinition,
+  DimensionExtraFieldDefinition,
+  DimensionExtraFieldType,
+  DimensionUpdatePayload,
+  ToastMessage,
+} from '../types';
+
+interface DimensionsPageProps {
+  onToast: (toast: ToastMessage) => void;
+}
+
+interface ExtraFieldDraft extends DimensionExtraFieldDefinition {
+  id: string;
+}
+
+const createEmptyExtraField = (id: string): ExtraFieldDraft => ({
+  id,
+  key: '',
+  label: '',
+  description: '',
+  data_type: 'string',
+  required: false,
+});
+
+const DimensionsPage = ({ onToast }: DimensionsPageProps) => {
+  const { dimensions, updateDimensions } = useAppState();
+  const [showEditor, setShowEditor] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [editing, setEditing] = useState<DimensionDefinition | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<DimensionDefinition | null>(null);
+  const [draft, setDraft] = useState<DimensionCreatePayload>({
+    code: '',
+    label: '',
+    description: '',
+    extra_fields: [],
+  });
+  const [draftFields, setDraftFields] = useState<ExtraFieldDraft[]>([]);
+
+  const sortedDimensions = useMemo(() => {
+    return [...dimensions].sort((a, b) => a.label.localeCompare(b.label));
+  }, [dimensions]);
+
+  const openCreateModal = () => {
+    setEditing(null);
+    setDraft({ code: '', label: '', description: '', extra_fields: [] });
+    setDraftFields([]);
+    setShowEditor(true);
+  };
+
+  const openEditModal = (dimension: DimensionDefinition) => {
+    setEditing(dimension);
+    setDraft({
+      code: dimension.code,
+      label: dimension.label,
+      description: dimension.description ?? '',
+      extra_fields: dimension.extra_fields,
+    });
+    setDraftFields(
+      dimension.extra_fields.map((field) => ({
+        ...field,
+        description: field.description ?? '',
+        id: `${field.key}`,
+      })),
+    );
+    setShowEditor(true);
+  };
+
+  const resetEditor = () => {
+    setShowEditor(false);
+    setEditing(null);
+    setDraft({ code: '', label: '', description: '', extra_fields: [] });
+    setDraftFields([]);
+  };
+
+  const handleFieldChange = <K extends keyof ExtraFieldDraft>(id: string, key: K, value: ExtraFieldDraft[K]) => {
+    setDraftFields((prev) => prev.map((field) => (field.id === id ? { ...field, [key]: value } : field)));
+  };
+
+  const addExtraField = () => {
+    setDraftFields((prev) => [...prev, createEmptyExtraField(`field-${Date.now()}-${prev.length}`)]);
+  };
+
+  const removeExtraField = (id: string) => {
+    setDraftFields((prev) => prev.filter((field) => field.id !== id));
+  };
+
+  const buildPayload = (): DimensionCreatePayload | DimensionUpdatePayload | null => {
+    if (!draft.code.trim() || !draft.label.trim()) {
+      onToast({ type: 'error', content: 'Dimension code and label are required.' });
+      return null;
+    }
+
+    const normalisedFields: DimensionExtraFieldDefinition[] = draftFields.map((field) => ({
+      key: field.key.trim(),
+      label: field.label.trim(),
+      description: field.description?.trim() || undefined,
+      data_type: field.data_type,
+      required: field.required,
+    }));
+
+    for (const field of normalisedFields) {
+      if (!field.key || !field.label) {
+        onToast({ type: 'error', content: 'Attribute keys and labels cannot be empty.' });
+        return null;
+      }
+    }
+
+    const payload: DimensionCreatePayload = {
+      code: draft.code.trim(),
+      label: draft.label.trim(),
+      description: draft.description?.trim() || undefined,
+      extra_fields: normalisedFields,
+    };
+
+    if (editing) {
+      const updatePayload: DimensionUpdatePayload = {
+        label: payload.label,
+        description: payload.description,
+        extra_fields: payload.extra_fields,
+      };
+      return updatePayload;
+    }
+
+    return payload;
+  };
+
+  const handleSave = async () => {
+    const payload = buildPayload();
+    if (!payload) {
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      if (editing) {
+        const updated = await updateDimension(editing.code, payload as DimensionUpdatePayload);
+        updateDimensions((prev) => prev.map((dimension) => (dimension.code === updated.code ? updated : dimension)));
+        onToast({ type: 'success', content: 'Dimension updated.' });
+      } else {
+        const created = await createDimension(payload as DimensionCreatePayload);
+        updateDimensions((prev) => [...prev, created]);
+        onToast({ type: 'success', content: 'Dimension created.' });
+      }
+      resetEditor();
+    } catch (error: unknown) {
+      console.error(error);
+      onToast({ type: 'error', content: 'Unable to save dimension.' });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!deleteTarget) {
+      return;
+    }
+    setIsSubmitting(true);
+    try {
+      await deleteDimension(deleteTarget.code);
+      updateDimensions((prev) => prev.filter((dimension) => dimension.code !== deleteTarget.code));
+      onToast({ type: 'success', content: 'Dimension deleted.' });
+      setDeleteTarget(null);
+    } catch (error: unknown) {
+      console.error(error);
+      onToast({ type: 'error', content: 'Unable to delete dimension. Remove related canonical values first.' });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const renderFieldTypeLabel = (type: DimensionExtraFieldType) => {
+    switch (type) {
+      case 'number':
+        return 'Number';
+      case 'boolean':
+        return 'Yes/No';
+      default:
+        return 'Text';
+    }
+  };
+
+  return (
+    <div className="d-flex flex-column gap-4" aria-label="Dimension registry">
+      <Card className="card-section">
+        <Card.Body className="d-flex flex-column gap-4">
+          <div className="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center gap-3">
+            <div>
+              <Card.Title as="h1" className="section-heading h4 mb-1">
+                Dimension registry
+              </Card.Title>
+              <Card.Text className="text-body-secondary mb-0">
+                Define the label, description, and custom attributes available for each canonical dimension. Attributes
+                surface in the canonical library for every value assigned to the dimension.
+              </Card.Text>
+            </div>
+            <Button variant="primary" onClick={openCreateModal}>
+              New dimension
+            </Button>
+          </div>
+
+          <div className="table-responsive">
+            <Table striped hover className="align-middle table-nowrap">
+              <thead>
+                <tr>
+                  <th>Code</th>
+                  <th>Label</th>
+                  <th>Description</th>
+                  <th>Attributes</th>
+                  <th className="text-end">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {sortedDimensions.length === 0 && (
+                  <tr>
+                    <td colSpan={5} className="text-center text-body-secondary py-4">
+                      No dimensions defined yet. Create one to begin collecting canonical values.
+                    </td>
+                  </tr>
+                )}
+                {sortedDimensions.map((dimension) => (
+                  <tr key={dimension.code}>
+                    <td className="fw-semibold text-monospace">{dimension.code}</td>
+                    <td>{dimension.label}</td>
+                    <td>{dimension.description || '—'}</td>
+                    <td>
+                      {dimension.extra_fields.length === 0 ? (
+                        '—'
+                      ) : (
+                        <div className="d-flex flex-wrap gap-2">
+                          {dimension.extra_fields.map((field) => (
+                            <Badge key={field.key} bg="info" text="dark">
+                              {field.label} · {renderFieldTypeLabel(field.data_type)}
+                              {field.required ? ' · required' : ''}
+                            </Badge>
+                          ))}
+                        </div>
+                      )}
+                    </td>
+                    <td className="text-end">
+                      <div className="d-inline-flex gap-2">
+                        <Button size="sm" variant="outline-primary" onClick={() => openEditModal(dimension)}>
+                          Edit
+                        </Button>
+                        <Button size="sm" variant="outline-danger" onClick={() => setDeleteTarget(dimension)}>
+                          Delete
+                        </Button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </Table>
+          </div>
+        </Card.Body>
+      </Card>
+
+      <Modal show={showEditor} onHide={resetEditor} size="lg" centered>
+        <Modal.Header closeButton>
+          <Modal.Title>{editing ? 'Edit dimension' : 'New dimension'}</Modal.Title>
+        </Modal.Header>
+        <Modal.Body className="d-flex flex-column gap-4">
+          <Row className="g-3">
+            <Col md={4}>
+              <Form.Group controlId="dimension-code">
+                <Form.Label>Code</Form.Label>
+                <Form.Control
+                  type="text"
+                  value={draft.code}
+                  onChange={(event) => setDraft((prev) => ({ ...prev, code: event.target.value }))}
+                  placeholder="e.g. region"
+                  disabled={Boolean(editing)}
+                />
+                <Form.Text className="text-body-secondary">
+                  Immutable identifier used by canonical values and mappings.
+                </Form.Text>
+              </Form.Group>
+            </Col>
+            <Col md={8}>
+              <Form.Group controlId="dimension-label">
+                <Form.Label>Label</Form.Label>
+                <Form.Control
+                  type="text"
+                  value={draft.label}
+                  onChange={(event) => setDraft((prev) => ({ ...prev, label: event.target.value }))}
+                  placeholder="Human-friendly dimension name"
+                />
+              </Form.Group>
+            </Col>
+          </Row>
+          <Form.Group controlId="dimension-description">
+            <Form.Label>Description</Form.Label>
+            <Form.Control
+              as="textarea"
+              rows={3}
+              value={draft.description ?? ''}
+              onChange={(event) => setDraft((prev) => ({ ...prev, description: event.target.value }))}
+              placeholder="Optional description for reviewers"
+            />
+          </Form.Group>
+
+          <div className="d-flex flex-column gap-3">
+            <div className="d-flex justify-content-between align-items-center">
+              <div>
+                <h2 className="h6 mb-1">Additional attributes</h2>
+                <p className="text-body-secondary mb-0">
+                  Define custom fields captured for canonical values in this dimension. They will appear in the canonical
+                  library editor.
+                </p>
+              </div>
+              <Button variant="outline-primary" size="sm" onClick={addExtraField}>
+                Add attribute
+              </Button>
+            </div>
+
+            {draftFields.length === 0 && (
+              <p className="text-body-secondary mb-0">No attributes defined. Canonical values will only collect label and description.</p>
+            )}
+
+            {draftFields.map((field) => (
+              <Card key={field.id} className="border-0 shadow-sm">
+                <Card.Body className="d-flex flex-column gap-3">
+                  <Row className="g-3 align-items-end">
+                    <Col md={4}>
+                      <Form.Group controlId={`field-key-${field.id}`}>
+                        <Form.Label>Key</Form.Label>
+                        <Form.Control
+                          type="text"
+                          value={field.key}
+                          onChange={(event) => handleFieldChange(field.id, 'key', event.target.value)}
+                          placeholder="e.g. iso_code"
+                        />
+                      </Form.Group>
+                    </Col>
+                    <Col md={4}>
+                      <Form.Group controlId={`field-label-${field.id}`}>
+                        <Form.Label>Label</Form.Label>
+                        <Form.Control
+                          type="text"
+                          value={field.label}
+                          onChange={(event) => handleFieldChange(field.id, 'label', event.target.value)}
+                          placeholder="Display name"
+                        />
+                      </Form.Group>
+                    </Col>
+                    <Col md={3}>
+                      <Form.Group controlId={`field-type-${field.id}`}>
+                        <Form.Label>Type</Form.Label>
+                        <Form.Select
+                          value={field.data_type}
+                          onChange={(event) => handleFieldChange(field.id, 'data_type', event.target.value as DimensionExtraFieldType)}
+                        >
+                          <option value="string">Text</option>
+                          <option value="number">Number</option>
+                          <option value="boolean">Yes/No</option>
+                        </Form.Select>
+                      </Form.Group>
+                    </Col>
+                    <Col md={1} className="text-end">
+                      <Button
+                        variant="outline-danger"
+                        size="sm"
+                        onClick={() => removeExtraField(field.id)}
+                        aria-label={`Remove attribute ${field.label || field.key || field.id}`}
+                      >
+                        Remove
+                      </Button>
+                    </Col>
+                  </Row>
+                  <Row className="g-3">
+                    <Col md={9}>
+                      <Form.Group controlId={`field-description-${field.id}`}>
+                        <Form.Label>Description</Form.Label>
+                        <Form.Control
+                          type="text"
+                          value={field.description ?? ''}
+                          onChange={(event) => handleFieldChange(field.id, 'description', event.target.value)}
+                          placeholder="Optional guidance for reviewers"
+                        />
+                      </Form.Group>
+                    </Col>
+                    <Col md={3} className="d-flex align-items-center">
+                      <Form.Check
+                        type="switch"
+                        id={`field-required-${field.id}`}
+                        label="Required"
+                        checked={field.required}
+                        onChange={(event) => handleFieldChange(field.id, 'required', event.target.checked)}
+                      />
+                    </Col>
+                  </Row>
+                </Card.Body>
+              </Card>
+            ))}
+          </div>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button variant="outline-secondary" onClick={resetEditor}>
+            Cancel
+          </Button>
+          <Button variant="primary" onClick={() => void handleSave()} disabled={isSubmitting}>
+            {isSubmitting ? (
+              <span className="d-inline-flex align-items-center gap-2">
+                <Spinner animation="border" size="sm" role="status" aria-hidden="true" />
+                Saving…
+              </span>
+            ) : (
+              'Save'
+            )}
+          </Button>
+        </Modal.Footer>
+      </Modal>
+
+      <Modal show={Boolean(deleteTarget)} onHide={() => setDeleteTarget(null)} centered>
+        <Modal.Header closeButton>
+          <Modal.Title>Delete dimension</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          Are you sure you want to delete the dimension <strong>{deleteTarget?.label}</strong> ({deleteTarget?.code})?
+          Canonical values linked to this dimension must be removed first.
+        </Modal.Body>
+        <Modal.Footer>
+          <Button variant="outline-secondary" onClick={() => setDeleteTarget(null)}>
+            Cancel
+          </Button>
+          <Button variant="danger" onClick={() => void handleDelete()} disabled={isSubmitting}>
+            {isSubmitting ? (
+              <span className="d-inline-flex align-items-center gap-2">
+                <Spinner animation="border" size="sm" role="status" aria-hidden="true" />
+                Deleting…
+              </span>
+            ) : (
+              'Delete'
+            )}
+          </Button>
+        </Modal.Footer>
+      </Modal>
+    </div>
+  );
+};
+
+export default DimensionsPage;

--- a/reviewer-ui/src/state/AppStateContext.tsx
+++ b/reviewer-ui/src/state/AppStateContext.tsx
@@ -11,18 +11,23 @@ import {
 import {
   fetchCanonicalValues,
   fetchConfig,
+  fetchDimensions,
 } from '../api';
-import type { CanonicalValue, SystemConfig } from '../types';
+import type { CanonicalValue, DimensionDefinition, SystemConfig } from '../types';
 
 interface AppStateValue {
   config: SystemConfig | null;
   canonicalValues: CanonicalValue[];
+  dimensions: DimensionDefinition[];
   isLoading: boolean;
   loadError: string | null;
   refresh: () => Promise<boolean>;
   setConfig: (updater: SystemConfig | null | ((prev: SystemConfig | null) => SystemConfig | null)) => void;
   updateCanonicalValues: (
     updater: CanonicalValue[] | ((prev: CanonicalValue[]) => CanonicalValue[]),
+  ) => void;
+  updateDimensions: (
+    updater: DimensionDefinition[] | ((prev: DimensionDefinition[]) => DimensionDefinition[]),
   ) => void;
 }
 
@@ -32,24 +37,31 @@ function sortCanonical(values: CanonicalValue[]): CanonicalValue[] {
   return [...values].sort((a, b) => a.canonical_label.localeCompare(b.canonical_label));
 }
 
+function sortDimensions(values: DimensionDefinition[]): DimensionDefinition[] {
+  return [...values].sort((a, b) => a.label.localeCompare(b.label));
+}
+
 export const AppStateProvider = ({ children }: PropsWithChildren) => {
   const [config, setConfig] = useState<SystemConfig | null>(null);
   const [canonicalValues, setCanonicalValues] = useState<CanonicalValue[]>([]);
+  const [dimensions, setDimensions] = useState<DimensionDefinition[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
 
   const refresh = useCallback(async (): Promise<boolean> => {
     setIsLoading(true);
     setLoadError(null);
-    const [configResult, canonicalResult] = await Promise.allSettled([
+    const [configResult, canonicalResult, dimensionResult] = await Promise.allSettled([
       fetchConfig(),
       fetchCanonicalValues(),
+      fetchDimensions(),
     ]);
 
     const errors: string[] = [];
     console.debug('App state refresh completed', {
       configStatus: configResult.status,
       canonicalStatus: canonicalResult.status,
+      dimensionStatus: dimensionResult.status,
     });
 
     if (configResult.status === 'fulfilled') {
@@ -64,6 +76,13 @@ export const AppStateProvider = ({ children }: PropsWithChildren) => {
     } else {
       console.error('Failed to load canonical values', canonicalResult.reason);
       errors.push('canonical library');
+    }
+
+    if (dimensionResult.status === 'fulfilled') {
+      setDimensions(sortDimensions(dimensionResult.value));
+    } else {
+      console.error('Failed to load dimensions', dimensionResult.reason);
+      errors.push('dimension registry');
     }
 
     setIsLoading(false);
@@ -86,6 +105,7 @@ export const AppStateProvider = ({ children }: PropsWithChildren) => {
     () => ({
       config,
       canonicalValues,
+      dimensions,
       isLoading,
       loadError,
       refresh,
@@ -101,8 +121,17 @@ export const AppStateProvider = ({ children }: PropsWithChildren) => {
           return sortCanonical(next);
         });
       },
+      updateDimensions: (updater) => {
+        setDimensions((prev) => {
+          const next =
+            typeof updater === 'function'
+              ? (updater as (values: DimensionDefinition[]) => DimensionDefinition[])(prev)
+              : updater;
+          return sortDimensions(next);
+        });
+      },
     }),
-    [canonicalValues, config, isLoading, loadError, refresh],
+    [canonicalValues, config, dimensions, isLoading, loadError, refresh],
   );
 
   return <AppStateContext.Provider value={value}>{children}</AppStateContext.Provider>;

--- a/reviewer-ui/src/types.ts
+++ b/reviewer-ui/src/types.ts
@@ -3,12 +3,14 @@ export interface CanonicalValue {
   dimension: string;
   canonical_label: string;
   description?: string | null;
+  attributes?: Record<string, string | number | boolean | null> | null;
 }
 
 export interface CanonicalValueUpdatePayload {
   dimension?: string;
   canonical_label?: string;
   description?: string | null;
+  attributes?: Record<string, string | number | boolean | null> | null;
 }
 
 export interface MatchCandidate {
@@ -170,3 +172,82 @@ export interface ValueMappingPayload {
 }
 
 export interface ValueMappingUpdatePayload extends Partial<ValueMappingPayload> {}
+
+export type DimensionExtraFieldType = 'string' | 'number' | 'boolean';
+
+export interface DimensionExtraFieldDefinition {
+  key: string;
+  label: string;
+  description?: string | null;
+  data_type: DimensionExtraFieldType;
+  required: boolean;
+}
+
+export interface DimensionDefinition {
+  id: number;
+  code: string;
+  label: string;
+  description?: string | null;
+  extra_fields: DimensionExtraFieldDefinition[];
+  created_at: string;
+  updated_at: string;
+}
+
+export interface DimensionCreatePayload {
+  code: string;
+  label: string;
+  description?: string | null;
+  extra_fields: DimensionExtraFieldDefinition[];
+}
+
+export interface DimensionUpdatePayload {
+  label?: string;
+  description?: string | null;
+  extra_fields?: DimensionExtraFieldDefinition[];
+}
+
+export interface DimensionRelationSummary {
+  id: number;
+  label: string;
+  description?: string | null;
+  parent_dimension_code: string;
+  child_dimension_code: string;
+  parent_dimension: DimensionDefinition;
+  child_dimension: DimensionDefinition;
+  link_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface DimensionRelationCreatePayload {
+  label: string;
+  parent_dimension_code: string;
+  child_dimension_code: string;
+  description?: string | null;
+}
+
+export interface DimensionRelationUpdatePayload {
+  label?: string;
+  description?: string | null;
+}
+
+export interface DimensionRelationLink {
+  id: number;
+  relation_id: number;
+  parent_canonical_id: number;
+  child_canonical_id: number;
+  parent_label: string;
+  child_label: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface DimensionRelationLinkPayload {
+  parent_canonical_id: number;
+  child_canonical_id: number;
+}
+
+export interface BulkImportResult {
+  created: CanonicalValue[];
+  errors: string[];
+}


### PR DESCRIPTION
## Summary
- add persistent models, schemas, and services for dimensions, dimension relations, and relation links
- expose CRUD APIs for dimensions, relations, and canonical bulk import with schema-aware validation
- refresh React reviewer UI with dimension management, relation management, and enriched canonical library workflows
- update docs, seeds, and tests to cover the new governance capabilities

## Testing
- PYTHONPATH=/workspace/refdata-hub pytest
- npm run build
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68de72b48880833290f83b5a410c11bc