### PR TITLE
Handle canonical import header aliases and emit structured logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ OpenMetadata-inspired experience and design principles.
 The FastAPI service now exposes a rich set of endpoints under `/api`:
 
 - `/reference/canonical` – full CRUD for canonical reference values.
-- `/reference/canonical/import` – parse CSV/TSV/Excel uploads and create canonical values in bulk.
+- `/reference/canonical/import` – parse CSV/TSV/Excel uploads and create canonical values in bulk. The importer now recognises
+  additional header aliases such as **Canonical Value**, **Dimension Name**, and **Long Description**, which prevents valid
+  spreadsheets from being rejected with a 400 error.
 - `/reference/dimensions` – manage the dimension catalog and attribute schema.
 - `/reference/dimension-relations` – define parent/child relationships and retrieve linked canonical pairs.
 - `/source/connections` – manage source system connection metadata.

--- a/docs/CANONICAL_LIBRARY.md
+++ b/docs/CANONICAL_LIBRARY.md
@@ -32,12 +32,17 @@ All changes are persisted via the `/api/reference/canonical` endpoints exposed b
 
 The importer accepts CSV, TSV, or Excel workbooks. Provide a header row describing each column—`dimension`, `label`, and
 `description` columns are detected automatically, along with any extra attribute keys defined for the target dimension. When
-pasting rows directly into the modal, the same headers should appear in the first line.
+pasting rows directly into the modal, the same headers should appear in the first line. Common aliases such as **Dimension
+Name**, **Canonical Value**, **Canonical Name**, **Canonical Description**, and **Long Description** are now recognised out of the
+box, ensuring legacy spreadsheets are parsed without manual edits.
 
 * Columns can be separated by commas, tabs, or multiple spaces when pasting raw text.
 * Empty dimension cells inherit the "Default dimension" value provided in the modal (useful when supplying single-dimension data).
 * Any attribute columns that match the dimension's schema (for example `code`, `iso_code`, or `unesco_level`) are parsed and
   stored alongside the canonical value.
+* Backend logs include the resolved filename, detected columns, and the number of created versus skipped rows. Check the FastAPI
+  container logs for entries such as `Bulk canonical import received` or `Bulk import aborted: missing canonical label column`
+  when diagnosing issues.
 * Uploading both a file and pasted rows prioritises the file contents; remove the file to import the pasted data instead.
 
 ### Abu Dhabi regional dataset

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -31,6 +31,11 @@ These messages confirm the configuration row exists and is returned to the UI. I
 
 Requests to `/api/reference/canonical` log the number of values returned. If the log shows `count: 0`, reseed the database or add canonical entries through the UI. A zero-length response will not trigger the toast, but the debug output can help verify the request succeeded.
 
+Bulk imports now produce structured log entries that call out the uploaded filename, detected headers, and any blocking
+validation issues. Look for messages such as `Bulk canonical import received` and `Bulk import aborted: missing canonical label
+column` to confirm whether the parser recognised the provided headers (including aliases like `Canonical Value` or `Long
+Description`). These logs make it easier to align the spreadsheet headers with the expected schema.
+
 ## 4. Retry with a hard refresh
 
 After addressing connectivity issues, perform a hard refresh (`Ctrl` + `Shift` + `R` on most browsers) to clear cached bundles and re-run the initial data fetch. The enhanced UI logging will confirm whether configuration and canonical data load successfully on subsequent attempts.


### PR DESCRIPTION
## Summary
- accept additional header aliases (Canonical Value, Dimension Name, Long Description, etc.) during canonical bulk imports and log parsing diagnostics
- surface structured info/warning logs for each import attempt so 400 errors can be diagnosed quickly
- document the new aliases and logging cues and cover them with a regression test

## Testing
- pytest
- npm install
- npm test -- --run src/api.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68df6433fce08332aea0e9c7d4d2e163