### PR TITLE
Add interactive bulk import mapping workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,11 @@ OpenMetadata-inspired experience and design principles.
 The FastAPI service now exposes a rich set of endpoints under `/api`:
 
 - `/reference/canonical` – full CRUD for canonical reference values.
-- `/reference/canonical/import` – parse CSV/TSV/Excel uploads and create canonical values in bulk. The importer now recognises
-  additional header aliases such as **Canonical Value**, **Dimension Name**, and **Long Description**, which prevents valid
-  spreadsheets from being rejected with a 400 error.
+- `/reference/canonical/import` – parse CSV/TSV/Excel uploads and create canonical values in bulk. Requests now accept an
+  explicit column mapping payload so spreadsheets with arbitrary headers can be harmonised, and optional dimension definitions
+  allow brand-new dimensions to be created automatically during an import.
+- `/reference/canonical/import/preview` – analyse an uploaded table and return detected columns, suggested roles, and proposed
+  dimension mappings. The Reviewer UI uses this endpoint to power the interactive bulk-import wizard.
 - `/reference/dimensions` – manage the dimension catalog and attribute schema.
 - `/reference/dimension-relations` – define parent/child relationships and retrieve linked canonical pairs.
 - `/source/connections` – manage source system connection metadata.

--- a/api/app/schemas.py
+++ b/api/app/schemas.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field, ConfigDict
 
@@ -311,6 +311,34 @@ class DimensionRelationLinkRead(DimensionRelationLinkBase):
     updated_at: datetime
 
     model_config = ConfigDict(from_attributes=True)
+
+
+class ProposedDimension(BaseModel):
+    code: str
+    label: str
+
+
+class BulkImportPreviewColumn(BaseModel):
+    name: str
+    sample: List[str]
+    suggested_role: Optional[str] = None
+    suggested_attribute_key: Optional[str] = None
+    suggested_dimension: Optional[str] = None
+
+
+class BulkImportPreview(BaseModel):
+    columns: List[BulkImportPreviewColumn]
+    suggested_dimension: Optional[str] = None
+    proposed_dimension: Optional[ProposedDimension] = None
+
+
+class BulkImportColumnMapping(BaseModel):
+    label: Optional[str] = None
+    dimension: Optional[str] = None
+    description: Optional[str] = None
+    attributes: Dict[str, str] = Field(default_factory=dict)
+    default_dimension: Optional[str] = None
+    dimension_definition: Optional[DimensionCreate] = None
 
 
 class BulkImportResult(BaseModel):

--- a/docs/CANONICAL_LIBRARY.md
+++ b/docs/CANONICAL_LIBRARY.md
@@ -11,8 +11,8 @@ The library page offers five key capabilities:
 1. **Filter & search** – Narrow the table by dimension and/or keyword to locate existing canonical values quickly.
 2. **Create & edit** – Launch the editor modal to add brand-new entries or update labels, dimensions, descriptions, and any
    dimension-specific attributes.
-3. **Bulk import** – Upload CSV/TSV/Excel files or paste tabular rows and let the importer detect headers, attributes, and
-   dimensions automatically.
+3. **Bulk import** – Upload CSV/TSV/Excel files or paste tabular rows, review the automatic column suggestions, and map headers
+   to canonical fields before committing the import.
 4. **Attributes** – Capture the extra fields defined for the active dimension (for example, codes or international identifiers)
    alongside each canonical value.
 5. **Export** – Download the filtered table to CSV for auditing or offline collaboration. The export includes attribute columns
@@ -30,19 +30,19 @@ All changes are persisted via the `/api/reference/canonical` endpoints exposed b
 
 ## Bulk import walkthrough
 
-The importer accepts CSV, TSV, or Excel workbooks. Provide a header row describing each column—`dimension`, `label`, and
-`description` columns are detected automatically, along with any extra attribute keys defined for the target dimension. When
-pasting rows directly into the modal, the same headers should appear in the first line. Common aliases such as **Dimension
-Name**, **Canonical Value**, **Canonical Name**, **Canonical Description**, and **Long Description** are now recognised out of the
-box, ensuring legacy spreadsheets are parsed without manual edits.
+The importer accepts CSV, TSV, or Excel workbooks. Provide a header row describing each column; the preview step inspects the
+headers and sample rows, proposes sensible defaults (label, dimension, description, and attribute candidates), and lets you map
+or ignore each column before creating any records. When the dataset targets a brand-new dimension, you can capture the dimension
+label and optional description inline—the backend will create the dimension and its attribute schema automatically during the
+import.
 
 * Columns can be separated by commas, tabs, or multiple spaces when pasting raw text.
-* Empty dimension cells inherit the "Default dimension" value provided in the modal (useful when supplying single-dimension data).
-* Any attribute columns that match the dimension's schema (for example `code`, `iso_code`, or `unesco_level`) are parsed and
-  stored alongside the canonical value.
+* Empty dimension cells inherit the selected target dimension when no dimension column is mapped—helpful for single-dimension
+  datasets.
+* Attribute columns can be mapped to existing schema keys or defined on the fly for new dimensions. Attribute types default to
+  text but can be adjusted to numeric or boolean as part of the mapping step.
 * Backend logs include the resolved filename, detected columns, and the number of created versus skipped rows. Check the FastAPI
-  container logs for entries such as `Bulk canonical import received` or `Bulk import aborted: missing canonical label column`
-  when diagnosing issues.
+  container logs for entries such as `Bulk canonical import received` or `Generated bulk import preview` when diagnosing issues.
 * Uploading both a file and pasted rows prioritises the file contents; remove the file to import the pasted data instead.
 
 ### Abu Dhabi regional dataset
@@ -58,8 +58,11 @@ To bulk load the dataset:
    cat docs/data/abu_dhabi_canonical.tsv
    ```
 2. Copy all rows starting from the second line (skip the header row).
-3. In the Reviewer UI, select **Bulk import** → either upload the TSV file or paste the copied rows → click **Import rows**.
-4. The importer reports how many records were created, highlights any issues inline, and automatically sorts the additions alongside existing values.
+3. In the Reviewer UI, select **Bulk import**, upload the TSV file (or paste the copied rows), and click **Review mappings**.
+4. Map the detected columns to the canonical label, dimension (or default dimension), and any attributes. Adjust attribute data
+   types if you're creating a new dimension.
+5. Click **Import rows** to create the records. The importer reports how many values were created, highlights any issues inline,
+   and automatically sorts the additions alongside existing values.
 
 ### Tips for custom datasets
 

--- a/reviewer-ui/src/api.ts
+++ b/reviewer-ui/src/api.ts
@@ -1,4 +1,5 @@
 import type {
+  BulkImportPreview,
   BulkImportResult,
   CanonicalValue,
   CanonicalValueUpdatePayload,
@@ -142,6 +143,13 @@ export async function deleteCanonicalValue(id: number): Promise<void> {
 
 export async function bulkImportCanonicalValues(formData: FormData): Promise<BulkImportResult> {
   return apiFetchJson<BulkImportResult>('/api/reference/canonical/import', {
+    method: 'POST',
+    body: formData,
+  });
+}
+
+export async function previewBulkImportCanonicalValues(formData: FormData): Promise<BulkImportPreview> {
+  return apiFetchJson<BulkImportPreview>('/api/reference/canonical/import/preview', {
     method: 'POST',
     body: formData,
   });

--- a/reviewer-ui/src/types.ts
+++ b/reviewer-ui/src/types.ts
@@ -251,3 +251,31 @@ export interface BulkImportResult {
   created: CanonicalValue[];
   errors: string[];
 }
+
+export interface BulkImportPreviewColumn {
+  name: string;
+  sample: string[];
+  suggested_role?: 'label' | 'dimension' | 'description' | 'attribute';
+  suggested_attribute_key?: string;
+  suggested_dimension?: string;
+}
+
+export interface ProposedDimensionSuggestion {
+  code: string;
+  label: string;
+}
+
+export interface BulkImportPreview {
+  columns: BulkImportPreviewColumn[];
+  suggested_dimension?: string | null;
+  proposed_dimension?: ProposedDimensionSuggestion | null;
+}
+
+export interface BulkImportColumnMapping {
+  label?: string;
+  dimension?: string;
+  description?: string;
+  attributes: Record<string, string>;
+  default_dimension?: string;
+  dimension_definition?: DimensionCreatePayload;
+}


### PR DESCRIPTION
## Summary
- add a preview endpoint and mapping-aware import logic so canonical uploads can map arbitrary headers and create dimensions on demand
- extend API schemas and tests covering the preview, mapping, and new-dimension flows
- redesign the Reviewer UI bulk-import modal into a mapping wizard and document the new workflow

## Testing
- pytest
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df6d7ba75c83328dbb09bed259f5ce