### PR TITLE
Support multi-sheet canonical imports and duplicate resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ The FastAPI service now exposes a rich set of endpoints under `/api`:
   allow brand-new dimensions to be created automatically during an import. The loader now scans every worksheet in an Excel
   workbook, skips prefatory metadata blocks, and promotes the first detected header row even when it appears below merged
   title cells or version banners, making it resilient to the multi-sheet templates typically shared by governance teams.
+  When a workbook includes multiple tabs, the API reports every sheet so the UI can prompt the reviewer to pick which one to
+  import. Each request processes exactly one sheet, making it safe to work through large templates sequentially. The import
+  workflow also performs a dry run to surface existing canonical values before anything is written—reviewers can decide to
+  update the matching records in place or skip them entirely.
 - `/reference/canonical/import/preview` – analyse an uploaded table and return detected columns, suggested roles, and proposed
   dimension mappings. The Reviewer UI uses this endpoint to power the interactive bulk-import wizard.
 - `/reference/dimensions` – manage the dimension catalog and attribute schema.

--- a/api/app/schemas.py
+++ b/api/app/schemas.py
@@ -326,10 +326,22 @@ class BulkImportPreviewColumn(BaseModel):
     suggested_dimension: Optional[str] = None
 
 
+class BulkImportDuplicateRecord(BaseModel):
+    row_number: int
+    dimension: str
+    canonical_label: str
+    existing_value: CanonicalValueRead
+    incoming_description: Optional[str] = None
+    incoming_attributes: Dict[str, Any] = Field(default_factory=dict)
+
+
 class BulkImportPreview(BaseModel):
     columns: List[BulkImportPreviewColumn]
     suggested_dimension: Optional[str] = None
     proposed_dimension: Optional[ProposedDimension] = None
+    available_sheets: List[str] = Field(default_factory=list)
+    selected_sheet: Optional[str] = None
+    duplicates: List[BulkImportDuplicateRecord] = Field(default_factory=list)
 
 
 class BulkImportColumnMapping(BaseModel):
@@ -343,4 +355,6 @@ class BulkImportColumnMapping(BaseModel):
 
 class BulkImportResult(BaseModel):
     created: List[CanonicalValueRead]
+    updated: List[CanonicalValueRead] = Field(default_factory=list)
+    duplicates: List[BulkImportDuplicateRecord] = Field(default_factory=list)
     errors: List[str]

--- a/docs/CANONICAL_LIBRARY.md
+++ b/docs/CANONICAL_LIBRARY.md
@@ -37,6 +37,11 @@ backend now scans every worksheet, discards prefatory rows until it finds the fi
 below it even when earlier cells are merged. When the dataset targets a brand-new dimension, you can capture the dimension label
 and optional description inline—the backend will create the dimension and its attribute schema automatically during the import.
 
+- If an Excel workbook contains multiple sheets, the preview step now lists every sheet so you can choose which one to import.
+  Work through larger templates one tab at a time without having to split the workbook manually.
+- Every import now performs a dry run before committing rows. The UI highlights any canonical values that already exist and lets
+  you decide whether to update those entries or skip the duplicates entirely.
+
 * Columns can be separated by commas, tabs, or multiple spaces when pasting raw text.
 * Empty dimension cells inherit the selected target dimension when no dimension column is mapped—helpful for single-dimension
   datasets.
@@ -81,7 +86,8 @@ To bulk load the dataset:
   clearing a database.
 - **Import validation errors** – Ensure each row contains at least two columns (dimension + canonical label). Codes and
   descriptions may be optional but are strongly recommended.
-- **Duplicate records** – The API allows duplicates; run the export to CSV and deduplicate externally if necessary.
+- **Duplicate records** – Duplicates are surfaced during the dry run; choose whether to overwrite the existing canonical values
+  or skip the incoming rows directly in the importer.
 
 With these enhancements the canonical library is resilient enough to manage the full Abu Dhabi reference taxonomy and any future
 expansions.

--- a/reviewer-ui/src/types.ts
+++ b/reviewer-ui/src/types.ts
@@ -247,8 +247,19 @@ export interface DimensionRelationLinkPayload {
   child_canonical_id: number;
 }
 
+export interface BulkImportDuplicateRecord {
+  row_number: number;
+  dimension: string;
+  canonical_label: string;
+  existing_value: CanonicalValue;
+  incoming_description?: string | null;
+  incoming_attributes: Record<string, unknown>;
+}
+
 export interface BulkImportResult {
   created: CanonicalValue[];
+  updated: CanonicalValue[];
+  duplicates: BulkImportDuplicateRecord[];
   errors: string[];
 }
 
@@ -269,6 +280,9 @@ export interface BulkImportPreview {
   columns: BulkImportPreviewColumn[];
   suggested_dimension?: string | null;
   proposed_dimension?: ProposedDimensionSuggestion | null;
+  available_sheets: string[];
+  selected_sheet?: string | null;
+  duplicates: BulkImportDuplicateRecord[];
 }
 
 export interface BulkImportColumnMapping {


### PR DESCRIPTION
## Summary
- surface workbook sheet names during canonical import previews and allow the reviewer to pick which sheet to load
- add duplicate detection to the import pipeline with dry-run support so existing canonical values can be skipped or updated explicitly
- update the React importer workflow, documentation, and automated tests to cover sheet selection and duplicate resolution

## Testing
- pytest
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df7c7048948332be19982f601d2d88