### PR TITLE
Add connection test API and dynamic metadata selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,11 @@ The interface is organised into task-focused pages that surface the entire curat
 - **Canonical Library** – manage curated reference values, filter by dimension, import tabular data in bulk, and export the library to CSV.
 - **Dimensions** – maintain each dimension's code, label, description, and custom attribute schema.
 - **Dimension Relations** – model parent/child hierarchies such as regions to districts and manage canonical value pairings.
-- **Source Connections** – register and maintain connectivity metadata for upstream systems.
+- **Source Connections** – register and maintain connectivity metadata for upstream systems and verify credentials with the new
+  **Test connection** action before persisting changes.
 - **Field Mappings** – align source tables/fields to reference dimensions and ingest sample values for reconciliation analytics.
+  Available tables and columns are now surfaced directly from the connected database so analysts can choose valid metadata from
+  dropdowns instead of typing freeform text.
 - **Match Insights** – visualise match rates per mapping, inspect top outliers, and track overall harmonisation health.
 - **Suggestions** – approve semantic suggestions or manually link raw values to canonical standards.
 - **Mapping History** – audit every approved mapping, edit or retire entries, and export a normalised view per connection.
@@ -64,6 +67,12 @@ The FastAPI service now exposes a rich set of endpoints under `/api`:
 - `/reference/dimensions` – manage the dimension catalog and attribute schema.
 - `/reference/dimension-relations` – define parent/child relationships and retrieve linked canonical pairs.
 - `/source/connections` – manage source system connection metadata.
+- `/source/connections/test` – validate new connection details on demand and surface connection latency without saving the
+  record.
+- `/source/connections/{id}/tables` – discover available tables and views for a connection so mapping workflows can present
+  authoritative dropdowns.
+- `/source/connections/{id}/tables/{table}/fields` – inspect column metadata for a given table (or view) to power the field
+  selector in the reviewer UI.
 - `/source/connections/{id}/mappings` – create/update/delete field mappings to reference dimensions.
 - `/source/connections/{id}/samples` – ingest aggregated raw samples collected from source systems or manual uploads.
 - `/source/connections/{id}/match-stats` – compute match rates, top unmatched values, and semantic suggestions.

--- a/api/app/schemas.py
+++ b/api/app/schemas.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 from pydantic import BaseModel, Field, ConfigDict
 
@@ -114,6 +114,40 @@ class SourceConnectionUpdate(BaseModel):
     username: Optional[str] = None
     password: Optional[str] = Field(default=None, min_length=1)
     options: Optional[str] = None
+
+
+class SourceConnectionTestPayload(BaseModel):
+    name: Optional[str] = None
+    db_type: str
+    host: str
+    port: int = Field(default=5432, ge=1, le=65535)
+    database: str
+    username: str
+    password: Optional[str] = Field(default=None, min_length=1)
+    options: Optional[str] = None
+
+
+class SourceConnectionTestOverrides(SourceConnectionUpdate):
+    pass
+
+
+class SourceConnectionTestResult(BaseModel):
+    success: bool
+    message: str
+    latency_ms: Optional[float] = None
+
+
+class SourceTableMetadata(BaseModel):
+    name: str
+    schema: Optional[str] = None
+    type: Literal["table", "view"]
+
+
+class SourceFieldMetadata(BaseModel):
+    name: str
+    data_type: Optional[str] = None
+    nullable: Optional[bool] = None
+    default: Optional[str] = None
 
 
 class SourceFieldMappingBase(BaseModel):

--- a/api/app/services/source_connections.py
+++ b/api/app/services/source_connections.py
@@ -1,0 +1,312 @@
+"""Utilities for working with external source system connections."""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from dataclasses import dataclass
+from typing import Any, Iterable, Optional
+from urllib.parse import urlencode
+
+from sqlalchemy import inspect, text
+from sqlalchemy.engine import URL
+from sqlalchemy.exc import SQLAlchemyError
+from sqlmodel import create_engine
+
+logger = logging.getLogger(__name__)
+
+
+class SourceConnectionServiceError(Exception):
+    """Base error for source connection helpers."""
+
+
+@dataclass
+class ConnectionSettings:
+    """Lightweight representation of connection credentials."""
+
+    db_type: str
+    host: str
+    port: int
+    database: str
+    username: str
+    password: Optional[str] = None
+    options: Optional[str] = None
+    name: Optional[str] = None
+
+
+@dataclass
+class ParsedOptions:
+    """Structured representation of optional connection metadata."""
+
+    query: dict[str, str]
+    connect_args: dict[str, Any]
+    schema: Optional[str]
+
+
+def _normalise_query_value(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return str(value)
+
+
+def _parse_options(raw: Optional[str]) -> ParsedOptions:
+    if not raw:
+        return ParsedOptions(query={}, connect_args={}, schema=None)
+
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:  # pragma: no cover - defensive logging
+        logger.debug("Failed to parse connection options JSON", exc_info=exc)
+        raise SourceConnectionServiceError("Options must be valid JSON") from exc
+
+    if not isinstance(parsed, dict):
+        raise SourceConnectionServiceError("Options must decode to a JSON object")
+
+    query: dict[str, Any] = {}
+    connect_args: dict[str, Any] = {}
+    schema: Optional[str] = None
+
+    if "schema" in parsed:
+        schema_value = parsed.pop("schema")
+        if schema_value is not None and not isinstance(schema_value, str):
+            raise SourceConnectionServiceError("schema option must be a string")
+        schema = schema_value
+
+    if "query" in parsed:
+        query_value = parsed.pop("query")
+        if not isinstance(query_value, dict):
+            raise SourceConnectionServiceError("query option must be a JSON object")
+        query.update(query_value)
+
+    if "connect_args" in parsed:
+        connect_value = parsed.pop("connect_args")
+        if not isinstance(connect_value, dict):
+            raise SourceConnectionServiceError("connect_args option must be a JSON object")
+        connect_args.update(connect_value)
+
+    for key, value in parsed.items():
+        query[key] = value
+
+    normalised_query = {
+        str(key): _normalise_query_value(value)
+        for key, value in query.items()
+        if _normalise_query_value(value) is not None
+    }
+
+    return ParsedOptions(
+        query=normalised_query,
+        connect_args=connect_args,
+        schema=schema,
+    )
+
+
+def _build_sqlalchemy_url(settings: ConnectionSettings, query: dict[str, str]) -> URL | str:
+    dialect = settings.db_type.strip().lower()
+
+    if dialect in {"postgres", "postgresql", "postgresql+psycopg"}:
+        return URL.create(
+            "postgresql+psycopg",
+            username=settings.username or None,
+            password=settings.password or None,
+            host=settings.host or None,
+            port=settings.port or None,
+            database=settings.database or None,
+            query=query or None,
+        )
+
+    if dialect == "sqlite":
+        database = settings.database.strip()
+        if not database:
+            raise SourceConnectionServiceError("Database path is required for sqlite connections")
+
+        if database.startswith("sqlite:"):
+            if query:
+                separator = "&" if "?" in database else "?"
+                return f"{database}{separator}{urlencode(query)}"
+            return database
+
+        return URL.create("sqlite", database=database, query=query or None)
+
+    raise SourceConnectionServiceError(f"Unsupported database type '{settings.db_type}'")
+
+
+def _create_engine(settings: ConnectionSettings) -> tuple[Any, ParsedOptions]:
+    parsed = _parse_options(settings.options)
+    url = _build_sqlalchemy_url(settings, parsed.query)
+    engine = create_engine(url, pool_pre_ping=True, connect_args=parsed.connect_args)
+    return engine, parsed
+
+
+def _should_skip_table(dialect: str, schema: Optional[str], name: str) -> bool:
+    if dialect == "sqlite" and name.startswith("sqlite_"):
+        return True
+    if schema in {"pg_catalog", "information_schema"}:
+        return True
+    return False
+
+
+def test_connection(settings: ConnectionSettings) -> float:
+    try:
+        engine, _ = _create_engine(settings)
+    except SourceConnectionServiceError:
+        raise
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.debug(
+            "Failed to initialise engine for %s",
+            settings.name or settings.database,
+            exc_info=exc,
+        )
+        raise SourceConnectionServiceError(str(exc)) from exc
+
+    try:
+        start = time.perf_counter()
+        with engine.connect() as connection:
+            connection.execute(text("SELECT 1"))
+        elapsed_ms = (time.perf_counter() - start) * 1000
+    except SQLAlchemyError as exc:
+        logger.debug(
+            "Connection test failed for %s",
+            settings.name or settings.database,
+            exc_info=exc,
+        )
+        raise SourceConnectionServiceError(str(exc)) from exc
+    finally:
+        engine.dispose()
+
+    return float(elapsed_ms)
+
+
+def list_tables(settings: ConnectionSettings) -> list[dict[str, Any]]:
+    try:
+        engine, parsed = _create_engine(settings)
+    except SourceConnectionServiceError:
+        raise
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.debug("Failed to initialise engine for table discovery", exc_info=exc)
+        raise SourceConnectionServiceError(str(exc)) from exc
+
+    inspector = inspect(engine)
+    dialect = engine.dialect.name
+
+    try:
+        if parsed.schema:
+            schemas: Iterable[Optional[str]] = [parsed.schema]
+        else:
+            try:
+                schemas = inspector.get_schema_names()
+            except NotImplementedError:
+                schemas = [getattr(inspector, "default_schema_name", None)]
+
+        results: list[dict[str, Any]] = []
+        for schema in schemas:
+            try:
+                table_names = inspector.get_table_names(schema=schema)
+                view_names = inspector.get_view_names(schema=schema)
+            except SQLAlchemyError as exc:
+                logger.debug("Failed to inspect schema %s", schema, exc_info=exc)
+                raise SourceConnectionServiceError(str(exc)) from exc
+
+            for name in table_names:
+                if _should_skip_table(dialect, schema, name):
+                    continue
+                results.append({"name": name, "schema": schema, "type": "table"})
+
+            for name in view_names:
+                if _should_skip_table(dialect, schema, name):
+                    continue
+                results.append({"name": name, "schema": schema, "type": "view"})
+
+        unique: dict[tuple[Optional[str], str, str], dict[str, Any]] = {}
+        for item in results:
+            unique[(item.get("schema"), item["name"], item["type"])] = item
+
+        ordered = sorted(
+            unique.values(),
+            key=lambda item: ((item.get("schema") or ""), item["name"], item["type"]),
+        )
+        return ordered
+    finally:
+        engine.dispose()
+
+
+def list_fields(
+    settings: ConnectionSettings, table_name: str, schema: Optional[str]
+) -> list[dict[str, Any]]:
+    try:
+        engine, parsed = _create_engine(settings)
+    except SourceConnectionServiceError:
+        raise
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.debug("Failed to initialise engine for column discovery", exc_info=exc)
+        raise SourceConnectionServiceError(str(exc)) from exc
+
+    inspector = inspect(engine)
+    target_schema = schema if schema is not None else parsed.schema
+
+    try:
+        columns = inspector.get_columns(table_name, schema=target_schema)
+    except SQLAlchemyError as exc:
+        logger.debug(
+            "Failed to inspect columns for %s.%s",
+            target_schema,
+            table_name,
+            exc_info=exc,
+        )
+        raise SourceConnectionServiceError(str(exc)) from exc
+    finally:
+        engine.dispose()
+
+    fields: list[dict[str, Any]] = []
+    for column in columns:
+        column_type = column.get("type")
+        default = column.get("default")
+        fields.append(
+            {
+                "name": column["name"],
+                "data_type": str(column_type) if column_type is not None else None,
+                "nullable": column.get("nullable"),
+                "default": str(default) if default is not None else None,
+            }
+        )
+
+    fields.sort(key=lambda item: item["name"])
+    return fields
+
+
+def merge_settings(
+    connection: Any, overrides: Optional[dict[str, Any]] = None
+) -> ConnectionSettings:
+    data = {
+        "db_type": connection.db_type,
+        "host": connection.host,
+        "port": connection.port,
+        "database": connection.database,
+        "username": connection.username,
+        "password": connection.password,
+        "options": connection.options,
+        "name": getattr(connection, "name", None),
+    }
+
+    if overrides:
+        for key, value in overrides.items():
+            if value is None:
+                continue
+            if key == "password" and value == "":
+                continue
+            if key == "options" and value == "":
+                continue
+            data[key] = value
+
+    return ConnectionSettings(**data)
+
+
+def settings_from_payload(payload: dict[str, Any]) -> ConnectionSettings:
+    data = payload.copy()
+    if not data.get("password"):
+        data.pop("password", None)
+    if data.get("options") in {"", None}:
+        data.pop("options", None)
+    return ConnectionSettings(**data)

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -6,6 +6,8 @@
 - Capture synonyms and spelling variations (e.g., "Single", "Unmarried", "Never married").
 - Provide multilingual metadata to support future international roll-outs.
 - Model parent/child relationships between dimensions (e.g., region → district) and capture the canonical value pairings needed for drill-down analytics.
+- Inspect connected source systems in real time—connection records can be tested inline and their available tables/columns are
+  introspected to drive the mapping workflows without manual lookups.
 
 ## 2. Semantic Matching
 - Use NLP and embedding models to suggest standardized values for new raw inputs.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -27,7 +27,14 @@ DEBUG api.app.routes.config Configuration retrieved {'config_id': 1}
 
 These messages confirm the configuration row exists and is returned to the UI. If the API logs show errors, restart the service and ensure the database is reachable.
 
-## 3. Review canonical library availability
+## 3. Validate credentials with the Test connection action
+
+The Source Connections page now includes a **Test connection** button next to the save action. Use it to confirm new or updated
+credentials before committing them to the catalog. The Reviewer UI will display a toast with the outcome and measured latency, and
+the API logs an audit-friendly entry if the connection attempt fails. If the test reports an error, adjust the host, port, or
+options JSON without leaving the modal until it succeeds.
+
+## 4. Review canonical library availability
 
 Requests to `/api/reference/canonical` log the number of values returned. If the log shows `count: 0`, reseed the database or add canonical entries through the UI. A zero-length response will not trigger the toast, but the debug output can help verify the request succeeded.
 
@@ -36,11 +43,11 @@ validation issues. Look for messages such as `Bulk canonical import received` an
 column` to confirm whether the parser recognised the provided headers (including aliases like `Canonical Value` or `Long
 Description`). These logs make it easier to align the spreadsheet headers with the expected schema.
 
-## 4. Retry with a hard refresh
+## 5. Retry with a hard refresh
 
 After addressing connectivity issues, perform a hard refresh (`Ctrl` + `Shift` + `R` on most browsers) to clear cached bundles and re-run the initial data fetch. The enhanced UI logging will confirm whether configuration and canonical data load successfully on subsequent attempts.
 
-## 5. Resolve `canonicalvalue.attributes` missing column errors
+## 6. Resolve `canonicalvalue.attributes` missing column errors
 
 Deployments created before the JSON `attributes` column was added to the `canonicalvalue` table can surface the following stack trace during API startup:
 
@@ -50,7 +57,7 @@ sqlalchemy.exc.ProgrammingError: (psycopg.errors.UndefinedColumn) column canonic
 
 The backend now self-heals this legacy schema automatically by adding the column and backfilling existing rows with an empty JSON object. Restart the API container (or rerun `docker compose up --build`) to apply the fix. Once the service is back online, the Reviewer UI will be able to load canonical values and the error will no longer appear in the logs.
 
-## 6. Resolve TypeScript build failures around mocked props
+## 7. Resolve TypeScript build failures around mocked props
 
 When running `npm run build` locally or inside the Docker image, you may encounter errors similar to:
 

--- a/reviewer-ui/src/pages/FieldMappingsPage.test.tsx
+++ b/reviewer-ui/src/pages/FieldMappingsPage.test.tsx
@@ -1,0 +1,80 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import FieldMappingsPage from './FieldMappingsPage';
+
+const apiMocks = vi.hoisted(() => ({
+  fetchSourceConnections: vi.fn(),
+  fetchFieldMappings: vi.fn(),
+  fetchSourceTables: vi.fn(),
+  fetchSourceFields: vi.fn(),
+}));
+
+vi.mock('../api', () => ({
+  createFieldMapping: vi.fn(),
+  deleteFieldMapping: vi.fn(),
+  fetchFieldMappings: apiMocks.fetchFieldMappings,
+  fetchSourceConnections: apiMocks.fetchSourceConnections,
+  fetchSourceTables: apiMocks.fetchSourceTables,
+  fetchSourceFields: apiMocks.fetchSourceFields,
+  ingestSamples: vi.fn(),
+  updateFieldMapping: vi.fn(),
+}));
+
+apiMocks.fetchSourceConnections.mockResolvedValue([
+  {
+    id: 1,
+    name: 'warehouse',
+    db_type: 'postgres',
+    host: 'localhost',
+    port: 5432,
+    database: 'analytics',
+    username: 'svc',
+    options: null,
+    created_at: '',
+    updated_at: '',
+  },
+]);
+
+apiMocks.fetchFieldMappings.mockResolvedValue([]);
+apiMocks.fetchSourceTables.mockResolvedValue([
+  { name: 'customers', schema: 'public', type: 'table' },
+  { name: 'customer_view', schema: 'public', type: 'view' },
+]);
+apiMocks.fetchSourceFields.mockResolvedValue([
+  { name: 'id', data_type: 'integer' },
+  { name: 'email', data_type: 'text' },
+]);
+
+vi.mock('../state/AppStateContext', () => ({
+  useAppState: () => ({
+    canonicalValues: [
+      { dimension: 'region' },
+      { dimension: 'city' },
+    ],
+  }),
+}));
+
+describe('FieldMappingsPage metadata selectors', () => {
+  it('loads table and field metadata when a table is selected', async () => {
+    const onToast = vi.fn();
+    render(<FieldMappingsPage onToast={onToast} />);
+
+    await waitFor(() => expect(apiMocks.fetchSourceConnections).toHaveBeenCalled());
+
+    const [mappingTableSelect] = await screen.findAllByLabelText('Source table');
+    await waitFor(() => expect(apiMocks.fetchSourceTables).toHaveBeenCalledWith(1));
+
+    fireEvent.change(mappingTableSelect, { target: { value: 'public.customers' } });
+
+    await waitFor(() =>
+      expect(apiMocks.fetchSourceFields).toHaveBeenCalledWith(1, 'customers', 'public'),
+    );
+
+    const [fieldSelect] = screen.getAllByLabelText('Source field');
+    const optionLabels = Array.from(fieldSelect.querySelectorAll('option')).map(
+      (option) => option.textContent,
+    );
+    expect(optionLabels).toContain('id');
+  });
+});

--- a/reviewer-ui/src/types.ts
+++ b/reviewer-ui/src/types.ts
@@ -67,8 +67,7 @@ export interface SourceConnection {
   updated_at: string;
 }
 
-export interface SourceConnectionCreatePayload {
-  name: string;
+export interface SourceConnectionCredentials {
   db_type: string;
   host: string;
   port: number;
@@ -78,7 +77,34 @@ export interface SourceConnectionCreatePayload {
   options?: string | null;
 }
 
+export interface SourceConnectionCreatePayload extends SourceConnectionCredentials {
+  name: string;
+}
+
 export interface SourceConnectionUpdatePayload extends Partial<SourceConnectionCreatePayload> {}
+
+export interface SourceConnectionTestPayload extends SourceConnectionCredentials {
+  name?: string;
+}
+
+export interface SourceConnectionTestResult {
+  success: boolean;
+  message: string;
+  latency_ms?: number | null;
+}
+
+export interface SourceTableMetadata {
+  name: string;
+  schema?: string | null;
+  type: 'table' | 'view';
+}
+
+export interface SourceFieldMetadata {
+  name: string;
+  data_type?: string | null;
+  nullable?: boolean | null;
+  default?: string | null;
+}
 
 export interface SourceFieldMapping {
   id: number;


### PR DESCRIPTION
## Summary
- add a backend service for testing source connections and listing available tables and fields
- expose API routes and TypeScript client helpers for connection tests and metadata discovery, updating docs accordingly
- enhance the Connections and Field Mappings pages with inline testing flows and dropdowns sourced from live metadata

## Testing
- pytest
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68df871a06908332a2d73f931756877d